### PR TITLE
Adding in support for VNC to view running Behat tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Started at 25-05-2017, 19:04
 15 steps (15 passed)
 1m35.32s (41.60Mb)
 
+# Using VNC to view Behat tests
+
+1. Download a VNC client: https://www.realvnc.com/en/connect/download/viewer/
+2. With the containers running, enter 0.0.0.0:5900 as the port in VNC Viewer. You will be prompted for a password. The password is 'test' by default, but you can change it by editing ./selenium/Dockerfile
+3. You should be able to see an empty Desktop. When you run any Behat tests a browser will popup and you will see the tests execute.
+
 # Install for manual testing (optional)
 bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --adminpass="test" --adminemail="admin@example.com"
 # Access http://localhost:8000/ on your browser

--- a/base.yml
+++ b/base.yml
@@ -20,6 +20,9 @@ services:
       POSTGRES_PASSWORD: "m@0dl3ing"
       POSTGRES_DB: moodle
   selenium:
-    image: selenium/standalone-firefox:2.53.1
+    image: selenium/standalone-firefox-debug:2.53.1
+    build: ./selenium/
+    ports:
+      - 5900:5900
     volumes:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html:ro"

--- a/selenium.chrome.yml
+++ b/selenium.chrome.yml
@@ -4,6 +4,6 @@ services:
     environment:
       MOODLE_DOCKER_BROWSER: chrome
   selenium:
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome-debug
     volumes:
         - /dev/shm:/dev/shm

--- a/selenium/Dockerfile
+++ b/selenium/Dockerfile
@@ -1,0 +1,4 @@
+FROM selenium/standalone-firefox-debug:2.53.1
+
+RUN mkdir -p ~/.vnc \
+  && x11vnc -storepasswd test ~/.vnc/passwd


### PR DESCRIPTION
We had some of our talented student developers tackle on enabling someone to view Behat tests using VNC. Check it out.