### PR TITLE
Make MOODLE_DOCKER_WWWROOT environment variable mandatory

### DIFF
--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+if [ ! -d "$MOODLE_DOCKER_WWWROOT" ];
+then
+    echo 'Error: $MOODLE_DOCKER_WWWROOT is not set or not an existing directory'
+    exit 1
+fi
+
 if [ -z "$MOODLE_DOCKER_DB" ];
 then
     echo 'Error: $MOODLE_DOCKER_DB is not set'

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -1,6 +1,11 @@
 @ECHO OFF
 
-if "%MOODLE_DOCKER_DB%"=="" (
+IF NOT EXIST "%MOODLE_DOCKER_WWWROOT%" (
+    ECHO Error: MOODLE_DOCKER_WWWROOT is not set or not an existing directory
+    EXIT /B 1
+)
+
+IF "%MOODLE_DOCKER_DB%"=="" (
     ECHO Error: MOODLE_DOCKER_DB is not set
     EXIT /B 1
 )


### PR DESCRIPTION
If MOODLE_DOCKER_WWWROOT environment variable is not set, there are error messages when spinning up the moodle-docker containers:

```
$ bin/moodle-docker-compose up -d
WARNING: The MOODLE_DOCKER_WWWROOT variable is not set. Defaulting to a blank string.
Recreating moodledocker_selenium_1 ... 
Recreating moodledocker_selenium_1
moodledocker_db_1 is up-to-date
moodledocker_mailhog_1 is up-to-date
Recreating moodledocker_webserver_1 ... 
Recreating moodledocker_selenium_1 ... error

Recreating moodledocker_webserver_1 ... error

ERROR: for moodledocker_webserver_1  Cannot create container for service webserver: create .: volume name is too short, names should be at least two alphanumeric characters

ERROR: for webserver  Cannot create container for service webserver: create .: volume name is too short, names should be at least two alphanumeric characters

ERROR: for selenium  Cannot create container for service selenium: create .: volume name is too short, names should be at least two alphanumeric characters
ERROR: Encountered errors while bringing up the project.
```

This can be avoided by making MOODLE_DOCKER_WWWROOT environment variable mandatory, similarly to MOODLE_DOCKER_DB