### PR TITLE
Add support for locally hosted exttests

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -20,6 +20,8 @@ services:
       POSTGRES_USER: moodle
       POSTGRES_PASSWORD: "m@0dl3ing"
       POSTGRES_DB: moodle
+  exttests:
+    image: moodlehq/moodle-exttests
   selenium:
     image: "selenium/standalone-firefox${MOODLE_DOCKER_SELENIUM_SUFFIX}:2.53.1"
     volumes:

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -38,6 +38,7 @@ $CFG->passwordpolicy = 0;
 
 $CFG->phpunit_dataroot  = '/var/www/phpunitdata';
 $CFG->phpunit_prefix = 't_';
+define('TEST_EXTERNAL_FILES_HTTP_URL', 'http://exttests');
 
 $CFG->behat_wwwroot   = 'http://webserver';
 $CFG->behat_dataroot  = '/var/www/behatdata';


### PR DESCRIPTION
To avoid unnecessary dependency upon download.moodle.org, this makes use
of locally hosted external tests using an additional docker image.

This only adds HTTP external tests.
HTTPS external tests will require more in-depth changes due to use of
SSL certificates.

Fixes #70.