### PR TITLE
Add possibility to use an alternative config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ This repository contains Docker configuration aimed at Moodle developers and tes
 ```bash
 # Set up path to Moodle code
 export MOODLE_DOCKER_WWWROOT=/path/to/moodle/code
+
 # Choose a db server (Currently supported: pgsql, mariadb, mysql, mssql, oracle)
 export MOODLE_DOCKER_DB=pgsql
 
-# Ensure customized config.php for the Docker containers is in place
-cp config.docker-template.php $MOODLE_DOCKER_WWWROOT/config.php
+# Ensure customized config.php for the Docker containers is in place. For
+# simple test run it should be OK using config.docker-template.php without
+# modifications by providing its location in MOODLE_DOCKER_CONFIGFILE env
+# variable. If MOODLE_DOCKER_CONFIGFILE is not defined,
+# $MOODLE_DOCKER_WWWROOT/config.php is used instead.
+export MOODLE_DOCKER_CONFIGFILE=$(pwd)/config.docker-template.php
 
 # Start up containers
 bin/moodle-docker-compose up -d
@@ -125,7 +130,8 @@ You can change the configuration of the docker images by setting various environ
 |-------------------------------------------|-----------|---------------------------------------|---------------|------------------------------------------------------------------------------|
 | `MOODLE_DOCKER_DB`                        | yes       | pgsql, mariadb, mysql, mssql, oracle  | none          | The database server to run against                                           |
 | `MOODLE_DOCKER_WWWROOT`                   | yes       | path on your file system              | none          | The path to the Moodle codebase you intend to test                           |
-| `MOODLE_DOCKER_PHP_VERSION`               | no        | 7.3, 7.2, 7.1, 7.0, 5.6                         | 7.1           | The php version to use                                                       |
+| `MOODLE_DOCKER_CONFIGFILE`                | no        | path on your file system              | config.php    | Alternative location for config.php to use                                   |
+| `MOODLE_DOCKER_PHP_VERSION`               | no        | 7.3, 7.2, 7.1, 7.0, 5.6               | 7.1           | The php version to use                                                       |
 | `MOODLE_DOCKER_BROWSER`                   | no        | firefox, chrome                       | firefox       | The browser to run Behat against                                             |
 | `MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES` | no        | any value                             | not set       | If set, dependencies for memcached, redis, solr, and openldap are added      |
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |

--- a/base.yml
+++ b/base.yml
@@ -6,6 +6,7 @@ services:
       - db
     volumes:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html"
+      - "${MOODLE_DOCKER_CONFIGFILE}:/var/www/html/config.php"
       - "${ASSETDIR}/web/apache2_faildumps.conf:/etc/apache2/conf-enabled/apache2_faildumps.conf"
     environment:
       MOODLE_DOCKER_DBTYPE: pgsql

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -74,6 +74,8 @@ then
     dockercompose="${dockercompose} -f ${basedir}/webserver.port.yml"
 fi
 
+# Alternative config.php
+export MOODLE_DOCKER_CONFIGFILE=${MOODLE_DOCKER_CONFIGFILE:-${MOODLE_DOCKER_WWWROOT}/config.php}
 
 # Mac OS Compatbility
 if [[ "$(uname)" == "Darwin" ]]; then


### PR DESCRIPTION
As a developer, I want to have an option to specify alternative config.php file, so that I can run tests on a code I am working currently without the need to modify existing config.php.

In reality, default template will work for user without modification, so in order to run unit test all developer needs to do is:
```
clone https://github.com/moodlehq/moodle-docker.git
cd moodle-docker
export MOODLE_DOCKER_WWWROOT=/path/to/moodle/code
export MOODLE_DOCKER_DB=pgsql
export MOODLE_DOCKER_CONFIGFILE=$(pwd)/config.docker-template.php
bin/moodle-docker-compose up -d
bin/moodle-docker-compose exec webserver php admin/tool/phpunit/cli/init.php
bin/moodle-docker-compose exec webserver vendor/bin/phpunit auth_manual_testcase auth/manual/tests/manual_test.php
```