### PR TITLE
Pin postgres to 9.6.7 because 9.6.8 leads to DDL failures

### DIFF
--- a/base.yml
+++ b/base.yml
@@ -15,7 +15,7 @@ services:
       MOODLE_DOCKER_BROWSER: firefox
       MOODLE_DOCKER_WEB_HOST: "${MOODLE_DOCKER_WEB_HOST}"
   db:
-    image: postgres:9
+    image: postgres:9.6.7
     environment:
       POSTGRES_USER: moodle
       POSTGRES_PASSWORD: "m@0dl3ing"


### PR DESCRIPTION
Since this weekend, we have detected that all the postgres jobs have started to fail. It seems that the reason has been the new PG 9.6.8 release (March 1st 2018):

https://www.postgresql.org/docs/9.6/static/release-9-6-8.html

So, as immediate action, this just pins moodle-docker to use PG 9.6.7 that works without known problem.

```
$ bin/moodle-docker-compose exec webserver vendor/bin/phpunit core_ddl_testcase lib/ddl/tests/ddl_test.php
Moodle 3.5dev (Build: 20180228), 856e07e4e7b45a848a8a44f6c6269673251ea310
Php: 7.2.1, pgsql: 9.6.7, OS: Linux 4.9.75-linuxkit-aufs x86_64
PHPUnit 6.4.4 by Sebastian Bergmann and contributors.

........................................                          40 / 40 (100%)

Time: 3.27 seconds, Memory: 38.00MB

OK (40 tests, 360 assertions)
```

