### PR TITLE
Add node container support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains Docker configuration aimed at Moodle developers and tes
 * All supported database servers (PostgreSQL, MySQL, Micosoft SQL Server, Oracle XE)
 * Behat/Selenium configuration for Firefox and Chrome
 * Catch-all smtp server and web interface to messages using [MailHog](https://github.com/mailhog/MailHog/)
+* Node container for Javascript compilation
 * All PHP Extensions enabled configured for external services (e.g. solr, ldap)
 * All supported PHP versions
 * Zero-configuration approach

--- a/base.yml
+++ b/base.yml
@@ -26,3 +26,9 @@ services:
     image: "selenium/standalone-firefox${MOODLE_DOCKER_SELENIUM_SUFFIX}:2.53.1"
     volumes:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html:ro"
+  node:
+    build:
+      context: ./
+      dockerfile: node.dockerfile
+    volumes:
+      - "${MOODLE_DOCKER_WWWROOT}:/var/www/html

--- a/bin/start-grunt.sh
+++ b/bin/start-grunt.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+until cd /var/www/html && npm install
+do
+    echo "Retrying npm install"
+done
+grunt watch

--- a/node.dockerfile
+++ b/node.dockerfile
@@ -1,0 +1,13 @@
+FROM debian:stretch-slim
+
+RUN apt-get update && apt-get install -my gnupg curl
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+
+RUN apt-get clean
+RUN apt-get update
+RUN apt-get install -y \
+        nodejs
+
+RUN /usr/bin/npm install -g grunt-cli
+ADD ./bin/start-grunt.sh .
+CMD ./start-grunt.sh


### PR DESCRIPTION
This adds a node container, locked at the necessary core-supported version, for running grunt tasks. The script is based on a Stackoverflow post: https://stackoverflow.com/a/37102013. It's a work-around to ensure that the Moodle web root is loaded before the container runs the command. The expected result (verified locally) is that grunt watch is running and compiling changes. There's probably a more elegant solution to this but I wanted to share what I'd gotten working.