### PR TITLE
Additional values for MOODLE_DOCKER_PHP_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can change the configuration of the docker images by setting various environ
 |-------------------------------------------|-----------|---------------------------------------|---------------|------------------------------------------------------------------------------|
 | `MOODLE_DOCKER_DB`                        | yes       | pgsql, mariadb, mysql, mssql, oracle  | none          | The database server to run against                                           |
 | `MOODLE_DOCKER_WWWROOT`                   | yes       | path on your file system              | none          | The path to the Moodle codebase you intend to test                           |
-| `MOODLE_DOCKER_PHP_VERSION`               | no        | 7.1, 7.0, 5.6                         | 7.1           | The php version to use                                                       |
+| `MOODLE_DOCKER_PHP_VERSION`               | no        | 7.3-stretch, 7.2-stretch, 7.1, 7.0, 5.6                         | 7.1           | The php version to use                                                       |
 | `MOODLE_DOCKER_BROWSER`                   | no        | firefox, chrome                       | firefox       | The browser to run Behat against                                             |
 | `MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES` | no        | any value                             | not set       | If set, dependencies for memcached, redis, solr, and openldap are added      |
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |


### PR DESCRIPTION
I tried setting MOODLE_DOCKER_PHP_VERSION to 7.2 and it did not change the PHP version. Turns out I needed to set it to 7.2-stretch. So I added in additional values that MOODLE_DOCKER_PHP_VERSION can be used to include 7.2-stretch and 7.3-stretch. 

It is not obvious that this is the proper values to change PHP to a version higher than 7.1.