### PR TITLE
Add mongodb container as part of external services

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can change the configuration of the docker images by setting various environ
 |-------------------------------------------|-----------|---------------------------------------|---------------|------------------------------------------------------------------------------|
 | `MOODLE_DOCKER_DB`                        | yes       | pgsql, mariadb, mysql, mssql, oracle  | none          | The database server to run against                                           |
 | `MOODLE_DOCKER_WWWROOT`                   | yes       | path on your file system              | none          | The path to the Moodle codebase you intend to test                           |
-| `MOODLE_DOCKER_PHP_VERSION`               | no        | 7.1, 7.0, 5.6                         | 7.1           | The php version to use                                                       |
+| `MOODLE_DOCKER_PHP_VERSION`               | no        | 7.3, 7.2, 7.1, 7.0, 5.6                         | 7.1           | The php version to use                                                       |
 | `MOODLE_DOCKER_BROWSER`                   | no        | firefox, chrome                       | firefox       | The browser to run Behat against                                             |
 | `MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES` | no        | any value                             | not set       | If set, dependencies for memcached, redis, solr, and openldap are added      |
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |

--- a/phpunit-external-services.yml
+++ b/phpunit-external-services.yml
@@ -7,6 +7,8 @@ services:
     image: memcached:1.4
   memcached1:
     image: memcached:1.4
+  mongo:
+    image: mongo:4.0
   redis:
     image: redis:3
   solr:


### PR DESCRIPTION
With https://github.com/moodlehq/moodle-php-apache/issues/16
adding support to mongodb tests back for PHP 7.1, 7.1 and 7.3
this enables them to be executed from moodle-docker.

Also, unrelated, README has been updated to show the 7.2 and 7.3
versions as available.