### PR TITLE
Enable Redis session tests back for PHP 7.2 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ services: docker
 fast_finish: true
 env:
     # Oracle jobs have been removed because there aren't public images anymore.
-    - "PHP=7.3 DB=pgsql   GIT=v3.7.0 SUITE=phpunit-full"
+    # We have set the "phpunit-full" to run against master because it's the
+    # weekly (3.8dev) where redis was fixed (MDL-60978). Once we have any working release
+    # including that fix, we'll be able to move back to tagged versions.
+    - "PHP=7.3 DB=pgsql   GIT=master SUITE=phpunit-full"
     - "PHP=7.2 DB=pgsql   GIT=v3.7.0 SUITE=phpunit"
     - "PHP=7.1 DB=pgsql   GIT=v3.7.0 SUITE=phpunit"
     - "PHP=7.0 DB=pgsql   GIT=v3.3.5 SUITE=phpunit"

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -58,11 +58,7 @@ if (getenv('MOODLE_DOCKER_PHPUNIT_EXTRAS')) {
     define('TEST_SEARCH_SOLR_INDEXNAME', 'test');
     define('TEST_SEARCH_SOLR_PORT', 8983);
 
-    // We need to keep Redis session tests disabled for PHP 7.2 and up. See MDL-60978.
-    if (version_compare(PHP_VERSION, '7.2.0', '<')) {
-        define('TEST_SESSION_REDIS_HOST', 'redis');
-    }
-
+    define('TEST_SESSION_REDIS_HOST', 'redis');
     define('TEST_CACHESTORE_REDIS_TESTSERVERS', 'redis');
 
     define('TEST_CACHESTORE_MONGODB_TESTSERVER', 'mongodb://mongo:27017');


### PR DESCRIPTION
(this is part of https://tracker.moodle.org/browse/MDLSITE-5876)

This reverts commit 2c7756fc9a51fade794dae67fe1bd780a4858c01.