### PR TITLE
Unpin 3.5.2 and allow any new 3.x release to be used

### DIFF
--- a/selenium.chrome.yml
+++ b/selenium.chrome.yml
@@ -4,6 +4,6 @@ services:
     environment:
       MOODLE_DOCKER_BROWSER: chrome
   selenium:
-    image: "selenium/standalone-chrome${MOODLE_DOCKER_SELENIUM_SUFFIX}:3.5.2"
+    image: "selenium/standalone-chrome${MOODLE_DOCKER_SELENIUM_SUFFIX}:3"
     volumes:
         - /dev/shm:/dev/shm


### PR DESCRIPTION
With [MDL-66378](https://tracker.moodle.org/browse/MDL-66378) and, specially,
https://github.com/moodlehq/php-webdriver/pull/1
we can continue using Chrome >= 76 because we are enforcing the
use of the legacy JsonWire protocol (instead of the default W3C one).

So it has been agreed that we'll allow any 3.x new release to be used in
order to detect problems earlier (we always can pin again if needed).