### PR TITLE
Bump versions to new 39 requirements and add 38 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,23 +3,39 @@ services: docker
 fast_finish: true
 env:
     # Oracle jobs have been removed because there aren't public images anymore.
+    # phpunit
+    # PostgreSQL highest, lowest php supported
     # We have set the "phpunit-full" to run against master.
-    - "PHP=7.3 DB=pgsql   GIT=master SUITE=phpunit-full" # PostgreSQL highest, lowest php supported
-    - "PHP=7.1 DB=pgsql   GIT=master SUITE=phpunit-full"
+    - "PHP=7.3 DB=pgsql   GIT=master SUITE=phpunit-full"
+    - "PHP=7.2 DB=pgsql   GIT=master SUITE=phpunit-full"
+    # Simpler "phpunit" for stables
+    - "PHP=7.3 DB=pgsql   GIT=v3.8.0 SUITE=phpunit"
+    - "PHP=7.1 DB=pgsql   GIT=v3.8.0 SUITE=phpunit"
     - "PHP=7.3 DB=pgsql   GIT=v3.7.2 SUITE=phpunit"
     - "PHP=7.1 DB=pgsql   GIT=v3.7.2 SUITE=phpunit"
     - "PHP=7.2 DB=pgsql   GIT=v3.5.8 SUITE=phpunit"
     - "PHP=7.0 DB=pgsql   GIT=v3.5.8 SUITE=phpunit"
-    - "PHP=7.3 DB=mssql   GIT=v3.7.2 SUITE=phpunit" # Other databases, only highest php supported
+    # Other databases, only highest php supported
+    - "PHP=7.3 DB=mssql   GIT=v3.8.0 SUITE=phpunit"
+    - "PHP=7.3 DB=mssql   GIT=v3.7.2 SUITE=phpunit"
     - "PHP=7.2 DB=mssql   GIT=v3.5.8 SUITE=phpunit"
+    - "PHP=7.3 DB=mysql   GIT=v3.8.0 SUITE=phpunit"
     - "PHP=7.3 DB=mysql   GIT=v3.7.2 SUITE=phpunit"
     - "PHP=7.2 DB=mysql   GIT=v3.5.8 SUITE=phpunit"
-    - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=phpunit" # MariaDB, only lowest php supported
+    # MariaDB, only lowest php supported
+    - "PHP=7.1 DB=mariadb GIT=v3.8.0 SUITE=phpunit"
+    - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=phpunit"
     - "PHP=7.0 DB=mariadb GIT=v3.5.8 SUITE=phpunit"
-    - "PHP=7.3 DB=pgsql   GIT=master SUITE=behat BROWSER=chrome" # PostgreSQL highest, lowest (2 browsers)
+    # behat
+    # PostgreSQL highest, lowest (2 browsers)
+    - "PHP=7.3 DB=pgsql   GIT=master SUITE=behat BROWSER=chrome"
     - "PHP=7.3 DB=pgsql   GIT=master SUITE=behat BROWSER=firefox"
-    - "PHP=7.1 DB=pgsql   GIT=master SUITE=behat BROWSER=chrome"
-    - "PHP=7.1 DB=pgsql   GIT=master SUITE=behat BROWSER=firefox"
+    - "PHP=7.2 DB=pgsql   GIT=master SUITE=behat BROWSER=chrome"
+    - "PHP=7.2 DB=pgsql   GIT=master SUITE=behat BROWSER=firefox"
+    - "PHP=7.3 DB=pgsql   GIT=v3.8.0 SUITE=behat BROWSER=chrome"
+    - "PHP=7.3 DB=pgsql   GIT=v3.8.0 SUITE=behat BROWSER=firefox"
+    - "PHP=7.1 DB=pgsql   GIT=v3.8.0 SUITE=behat BROWSER=chrome"
+    - "PHP=7.1 DB=pgsql   GIT=v3.8.0 SUITE=behat BROWSER=firefox"
     - "PHP=7.3 DB=pgsql   GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.3 DB=pgsql   GIT=v3.7.2 SUITE=behat BROWSER=firefox"
     - "PHP=7.1 DB=pgsql   GIT=v3.7.2 SUITE=behat BROWSER=chrome"
@@ -28,11 +44,16 @@ env:
     - "PHP=7.2 DB=pgsql   GIT=v3.5.8 SUITE=behat BROWSER=firefox"
     - "PHP=7.0 DB=pgsql   GIT=v3.5.8 SUITE=behat BROWSER=chrome"
     - "PHP=7.0 DB=pgsql   GIT=v3.5.8 SUITE=behat BROWSER=firefox"
-    - "PHP=7.3 DB=mssql   GIT=v3.7.2 SUITE=behat BROWSER=chrome" # Other databases, only highest php supported (2 browsers)
+    # Other databases, only highest php supported (1 browsers)
+    - "PHP=7.3 DB=mssql   GIT=v3.8.0 SUITE=behat BROWSER=firefox" # Other databases, only highest php supported (1 browsers)
+    - "PHP=7.3 DB=mssql   GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.2 DB=mssql   GIT=v3.5.8 SUITE=behat BROWSER=firefox"
+    - "PHP=7.3 DB=mysql   GIT=v3.8.0 SUITE=behat BROWSER=chrome"
     - "PHP=7.3 DB=mysql   GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.2 DB=mysql   GIT=v3.5.8 SUITE=behat BROWSER=firefox"
-    - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=behat BROWSER=chrome" # MariaDB, only lowest php supported (2 browsers)
+    # MariaDB, only lowest php supported (1 browsers)
+    - "PHP=7.1 DB=mariadb GIT=v3.8.0 SUITE=behat BROWSER=firefox"
+    - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.0 DB=mariadb GIT=v3.5.8 SUITE=behat BROWSER=firefox"
 install:
     - git clone --branch $GIT --depth 1 git://github.com/moodle/moodle $HOME/moodle


### PR DESCRIPTION
Apart from a small reorganization of comments, this just modifies the master tests to fulfill the 3.9 requirements and adds the 3.8 (just released) tests.