### PR TITLE
Add $CFG->pathtophp to config.php template

### DIFF
--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -31,6 +31,7 @@ $CFG->dataroot  = '/var/www/moodledata';
 $CFG->admin     = 'admin';
 $CFG->directorypermissions = 0777;
 $CFG->smtphosts = 'mailhog:1025';
+$CFG->pathtophp = '/usr/local/bin/php';
 
 // Debug options - possible to be controlled by flag in future..
 $CFG->debug = (E_ALL | E_STRICT); // DEBUG_DEVELOPER


### PR DESCRIPTION
This patch adds $CFG->pathtophp to the config.php template.
The goal of this addition is to be able to use "Run now" on /admin/tool/task/scheduledtasks.php without having to set any configurations first.