### PR TITLE
Mobile app support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ install:
     - export MOODLE_DOCKER_BROWSER=$BROWSER
     - export MOODLE_DOCKER_WWWROOT="$HOME/moodle"
     - export MOODLE_DOCKER_PHP_VERSION=$PHP
-    - export MOODLE_MOBILE_VERSION=$MOBILE
+    - export MOODLE_APP_VERSION=$MOBILE
 before_script:
     - tests/setup.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,6 +55,9 @@ env:
     - "PHP=7.1 DB=mariadb GIT=v3.8.0 SUITE=behat BROWSER=firefox"
     - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.0 DB=mariadb GIT=v3.5.8 SUITE=behat BROWSER=firefox"
+    # Mobile app
+    - "PHP=7.3 DB=pgsql GIT=master SUITE=app BROWSER=chrome MOBILE=next"
+    - "PHP=7.3 DB=pgsql GIT=master SUITE=app BROWSER=chrome MOBILE=latest"
 install:
     - git clone --branch $GIT --depth 1 git://github.com/moodle/moodle $HOME/moodle
     - cp config.docker-template.php $HOME/moodle/config.php
@@ -62,6 +65,7 @@ install:
     - export MOODLE_DOCKER_BROWSER=$BROWSER
     - export MOODLE_DOCKER_WWWROOT="$HOME/moodle"
     - export MOODLE_DOCKER_PHP_VERSION=$PHP
+    - export MOODLE_MOBILE_VERSION=$MOBILE
 before_script:
     - tests/setup.sh
 script:

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ You can change the configuration of the docker images by setting various environ
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |
 | `MOODLE_DOCKER_WEB_PORT`                  | no        | any integer value (or bind_ip:integer)| 127.0.0.1:8000| The port number for web. If set to 0, no port is used.<br/>If you want to bind to any host IP different from the default 127.0.0.1, you can specify it with the bind_ip:port format (0.0.0.0 means bind to all) |
 | `MOODLE_DOCKER_SELENIUM_VNC_PORT`         | no        | any integer value (or bind_ip:integer)| not set       | If set, the selenium node will expose a vnc session on the port specified. Similar to MOODLE_DOCKER_WEB_PORT, you can optionally define the host IP to bind to. If you just set the port, VNC binds to 127.0.0.1 |
+| `MOODLE_MOBILE_VERSION`                   | no        | next, latest, or an app version number| not set       | If set will start an instance of the Mmodle app if the chrome browser is selected |
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You can change the configuration of the docker images by setting various environ
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |
 | `MOODLE_DOCKER_WEB_PORT`                  | no        | any integer value (or bind_ip:integer)| 127.0.0.1:8000| The port number for web. If set to 0, no port is used.<br/>If you want to bind to any host IP different from the default 127.0.0.1, you can specify it with the bind_ip:port format (0.0.0.0 means bind to all) |
 | `MOODLE_DOCKER_SELENIUM_VNC_PORT`         | no        | any integer value (or bind_ip:integer)| not set       | If set, the selenium node will expose a vnc session on the port specified. Similar to MOODLE_DOCKER_WEB_PORT, you can optionally define the host IP to bind to. If you just set the port, VNC binds to 127.0.0.1 |
-| `MOODLE_MOBILE_VERSION`                   | no        | next, latest, or an app version number| not set       | If set will start an instance of the Mmodle app if the chrome browser is selected |
+| `MOODLE_APP_VERSION`                      | no        | next, latest, or an app version number| not set       | If set will start an instance of the Mmodle app if the chrome browser is selected |
 
 ## Advanced usage
 

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -44,6 +44,12 @@ if [ -f $filename ]; then
     dockercompose="${dockercompose} -f ${filename}"
 fi
 
+# Mobile app
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_MOBILE_VERSION" ]];
+then
+    dockercompose="${dockercompose} -f ${basedir}/moodle-app.yml"
+fi
+
 # Selenium browser
 if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" != "firefox" ]];
 then

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -45,7 +45,7 @@ if [ -f $filename ]; then
 fi
 
 # Mobile app
-if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_MOBILE_VERSION" ]];
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_APP_VERSION" ]];
 then
     dockercompose="${dockercompose} -f ${basedir}/moodle-app.yml"
 fi

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -35,7 +35,7 @@ if exist %filename% (
 )
 
 IF "%MOODLE_DOCKER_BROWSER%"=="chrome" (
-    IF NOT "%MOODLE_MOBILE_VERSION%"=="" (
+    IF NOT "%MOODLE_APP_VERSION%"=="" (
         SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\moodle-app.yml"
     )
 )

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -34,6 +34,12 @@ if exist %filename% (
     SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%filename%"
 )
 
+IF "%MOODLE_DOCKER_BROWSER%"=="chrome" (
+    IF NOT "%MOODLE_MOBILE_VERSION%"=="" (
+        SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\moodle-app.yml"
+    )
+)
+
 IF NOT "%MOODLE_DOCKER_BROWSER%"=="" (
     IF NOT "%MOODLE_DOCKER_BROWSER%"=="firefox" (
         SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\selenium.%MOODLE_DOCKER_BROWSER%.yml"

--- a/bin/moodle-docker-wait-for-app
+++ b/bin/moodle-docker-wait-for-app
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_MOBILE_VERSION" ]];
+then
+    until $basedir/bin/moodle-docker-compose logs mobileapp | grep -q 'dev server running: ';
+    do
+        echo 'Waiting for Moodle app to come up...'
+        sleep 15
+    done
+fi

--- a/bin/moodle-docker-wait-for-app
+++ b/bin/moodle-docker-wait-for-app
@@ -3,9 +3,9 @@ set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_MOBILE_VERSION" ]];
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_APP_VERSION" ]];
 then
-    until $basedir/bin/moodle-docker-compose logs mobileapp | grep -q 'dev server running: ';
+    until $basedir/bin/moodle-docker-compose logs moodleapp | grep -q 'dev server running: ';
     do
         echo 'Waiting for Moodle app to come up...'
         sleep 15

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -59,7 +59,7 @@ $CFG->behat_faildump_path = '/var/www/behatfaildumps';
 define('PHPUNIT_LONGTEST', true);
 
 if (getenv('MOODLE_DOCKER_APP')) {
-    $CFG->behat_ionic_wwwroot = 'http://mobileapp:8100';
+    $CFG->behat_ionic_wwwroot = 'http://moodleapp:8100';
 }
 
 if (getenv('MOODLE_DOCKER_PHPUNIT_EXTRAS')) {

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -58,7 +58,7 @@ $CFG->behat_faildump_path = '/var/www/behatfaildumps';
 
 define('PHPUNIT_LONGTEST', true);
 
-if (getenv('MOODLE_DOCKER_MOBILE')) {
+if (getenv('MOODLE_DOCKER_APP')) {
     $CFG->behat_ionic_wwwroot = 'http://mobileapp:8100';
 }
 

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -58,6 +58,10 @@ $CFG->behat_faildump_path = '/var/www/behatfaildumps';
 
 define('PHPUNIT_LONGTEST', true);
 
+if (getenv('MOODLE_DOCKER_MOBILE')) {
+    $CFG->behat_ionic_wwwroot = 'http://mobileapp:8100';
+}
+
 if (getenv('MOODLE_DOCKER_PHPUNIT_EXTRAS')) {
     define('TEST_SEARCH_SOLR_HOSTNAME', 'solr');
     define('TEST_SEARCH_SOLR_INDEXNAME', 'test');

--- a/moodle-app.yml
+++ b/moodle-app.yml
@@ -4,4 +4,4 @@ services:
     environment:
       MOODLE_DOCKER_MOBILE: "true"
   mobileapp:
-    image: "moodlehq/moodlemobile2:${MOODLE_MOBILE_VERSION}"
+    image: "moodlehq/moodleapp:${MOODLE_MOBILE_VERSION}"

--- a/moodle-app.yml
+++ b/moodle-app.yml
@@ -1,0 +1,7 @@
+version: "2"
+services:
+  webserver:
+    environment:
+      MOODLE_DOCKER_MOBILE: "true"
+  mobileapp:
+    image: "moodlehq/moodlemobile2:${MOODLE_MOBILE_VERSION}"

--- a/moodle-app.yml
+++ b/moodle-app.yml
@@ -2,6 +2,6 @@ version: "2"
 services:
   webserver:
     environment:
-      MOODLE_DOCKER_MOBILE: "true"
-  mobileapp:
-    image: "moodlehq/moodleapp:${MOODLE_MOBILE_VERSION}"
+      MOODLE_DOCKER_APP: "true"
+  moodleapp:
+    image: "moodlehq/moodleapp:${MOODLE_APP_VERSION}"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -26,5 +26,7 @@ echo "Starting up container"
 $basedir/bin/moodle-docker-compose up -d
 echo "Waiting for DB to come up"
 $basedir/bin/moodle-docker-wait-for-db
+echo "Waiting for Moodle app to come up"
+$basedir/bin/moodle-docker-wait-for-app
 echo "Running: $initcmd"
 $basedir/$initcmd

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -12,6 +12,9 @@ elif [ "$SUITE" = "phpunit-full" ];
 then
     export MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES=true
     initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php"
+elif [ "$SUITE" = "app" ];
+then
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
 else
     echo "Error, unknown suite '$SUITE'"
     exit 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,6 +12,9 @@ then
 elif [ "$SUITE" = "phpunit-full" ];
 then
     testcmd="bin/moodle-docker-compose exec -T webserver vendor/bin/phpunit --verbose"
+elif [ "$SUITE" = "app" ];
+then
+    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags=@app"
 else
     echo "Error, unknown suite '$SUITE'"
     exit 1


### PR DESCRIPTION
Adds a MOODLE_MOBILE_VERSION environment parameter do define a
Moodle app docker image.

If the browser is chrome and it is defined the mobile app will be started and
Moodle configured so it is available for behat tests.