### PR TITLE
Moodle app development

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ env:
     - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.0 DB=mariadb GIT=v3.5.8 SUITE=behat BROWSER=firefox"
     # Mobile app
-    - "PHP=7.3 DB=pgsql GIT=master SUITE=behat-app BROWSER=chrome APP=3.9.0"
+    - "PHP=7.3 DB=pgsql GIT=master SUITE=behat-app-development BROWSER=chrome APP_VERSION=3.9.0 APP_PATH=$HOME/app"
+    - "PHP=7.3 DB=pgsql GIT=master SUITE=behat-app BROWSER=chrome APP_VERSION=3.9.0"
 install:
     - git clone --branch $GIT --depth 1 git://github.com/moodle/moodle $HOME/moodle
     - cp config.docker-template.php $HOME/moodle/config.php
@@ -64,7 +65,8 @@ install:
     - export MOODLE_DOCKER_BROWSER=$BROWSER
     - export MOODLE_DOCKER_WWWROOT="$HOME/moodle"
     - export MOODLE_DOCKER_PHP_VERSION=$PHP
-    - export MOODLE_APP_VERSION=$APP
+    - export MOODLE_DOCKER_APP_PATH=$APP_PATH
+    - export MOODLE_APP_VERSION=$APP_VERSION
 before_script:
     - tests/setup.sh
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,7 @@ env:
     - "PHP=7.1 DB=mariadb GIT=v3.7.2 SUITE=behat BROWSER=chrome"
     - "PHP=7.0 DB=mariadb GIT=v3.5.8 SUITE=behat BROWSER=firefox"
     # Mobile app
-    - "PHP=7.3 DB=pgsql GIT=master SUITE=app BROWSER=chrome MOBILE=next"
-    - "PHP=7.3 DB=pgsql GIT=master SUITE=app BROWSER=chrome MOBILE=latest"
+    - "PHP=7.3 DB=pgsql GIT=master SUITE=behat-app BROWSER=chrome APP=3.9.0"
 install:
     - git clone --branch $GIT --depth 1 git://github.com/moodle/moodle $HOME/moodle
     - cp config.docker-template.php $HOME/moodle/config.php
@@ -65,7 +64,7 @@ install:
     - export MOODLE_DOCKER_BROWSER=$BROWSER
     - export MOODLE_DOCKER_WWWROOT="$HOME/moodle"
     - export MOODLE_DOCKER_PHP_VERSION=$PHP
-    - export MOODLE_APP_VERSION=$MOBILE
+    - export MOODLE_APP_VERSION=$APP
 before_script:
     - tests/setup.sh
 script:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,50 @@ Notes:
 * Mailhog is listening on `http://localhost:8000/_/mail` to view emails which Moodle has sent out.
 * The admin `username` you need to use for logging in is `admin` by default. You can customize it by passing `--adminuser='myusername'`
 
+## Use containers for running behat tests for the mobile app
+
+In order to run Behat tests for the mobile app, you need to install the [local_moodlemobileapp](https://github.com/moodlehq/moodle-local_moodlemobileapp) plugin in your Moodle site. Everything else should be the same as running standard Behat tests for Moodle. Make sure to filter tests using the `@app` tag.
+
+The Behat tests will be run against a container serving the mobile application, you have two options here:
+
+1. Use a docker image that includes the application code. You need to specify the `MOODLE_APP_VERSION` env variable and the [moodlehq/moodleapp](https://hub.docker.com/r/moodlehq/moodleapp) image will be downloaded from docker hub.
+
+2. Use a local copy of the application code and serve it through docker, similar to how the Moodle site is being served. Set the `MOODLE_DOCKER_APP_PATH` env variable to the codebase in you file system. This will assume that you've already initialized the app calling `npm install` and `npm run setup` locally.
+
+For both options, you also need to set `MOODLE_DOCKER_BROWSER` to "chrome".
+
+```bash
+# Install local_moodlemobileapp plugin
+git clone git://github.com/moodlehq/moodle-local_moodlemobileapp "$MOODLE_DOCKER_WWWROOT/local/moodlemobileapp"
+
+# Initialize behat environment
+bin/moodle-docker-compose exec webserver php admin/tool/behat/cli/init.php
+# [..]
+
+# Run behat tests
+bin/moodle-docker-compose exec -u www-data webserver php admin/tool/behat/cli/run.php --tags="@app&&@mod_login"
+Running single behat site:
+Moodle 4.0dev (Build: 20200615), a2b286ce176fbe361f0889abc8f30f043cd664ae
+Php: 7.2.30, pgsql: 11.8 (Debian 11.8-1.pgdg90+1), OS: Linux 5.3.0-61-generic x86_64
+Server OS "Linux", Browser: "chrome"
+Browser specific fixes have been applied. See http://docs.moodle.org/dev/Acceptance_testing#Browser_specific_fixes
+Started at 13-07-2020, 18:34
+.....................................................................
+
+4 scenarios (4 passed)
+69 steps (69 passed)
+3m3.17s (55.02Mb)
+```
+
+If you are going with the second option, this *can* be used for local development of the mobile app, given that the `moodleapp` container serves the app on the local 8100 port. However, this is intended to run Behat tests that require interacting with a local Moodle environment. Normal development should be easier calling `npm start` in the host system.
+
+By all means, if you don't want to have npm installed locally you can go full docker executing the following commands before starting the containers:
+
+```
+docker run --volume $MOODLE_DOCKER_APP_PATH:/app --workdir /app node:11 npm install
+docker run --volume $MOODLE_DOCKER_APP_PATH:/app --workdir /app node:11 npm run setup
+```
+
 ## Using VNC to view behat tests
 
 If `MOODLE_DOCKER_SELENIUM_VNC_PORT` is defined, selenium will expose a VNC session on the port specified so behat tests can be viewed in progress.
@@ -134,6 +178,7 @@ You can change the configuration of the docker images by setting various environ
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |
 | `MOODLE_DOCKER_WEB_PORT`                  | no        | any integer value (or bind_ip:integer)| 127.0.0.1:8000| The port number for web. If set to 0, no port is used.<br/>If you want to bind to any host IP different from the default 127.0.0.1, you can specify it with the bind_ip:port format (0.0.0.0 means bind to all) |
 | `MOODLE_DOCKER_SELENIUM_VNC_PORT`         | no        | any integer value (or bind_ip:integer)| not set       | If set, the selenium node will expose a vnc session on the port specified. Similar to MOODLE_DOCKER_WEB_PORT, you can optionally define the host IP to bind to. If you just set the port, VNC binds to 127.0.0.1 |
+| `MOODLE_DOCKER_APP_PATH`                  | no        | path on your file system              | not set       | If set and the chrome browser is selected, it will start an instance of the Moodle app from your local codebase |
 | `MOODLE_APP_VERSION`                      | no        | next, latest, or an app version number| not set       | If set will start an instance of the Moodle app if the chrome browser is selected |
 
 ## Using XDebug for live debugging

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ You can change the configuration of the docker images by setting various environ
 | `MOODLE_DOCKER_WEB_HOST`                  | no        | any valid hostname                    | localhost     | The hostname for web                                |
 | `MOODLE_DOCKER_WEB_PORT`                  | no        | any integer value (or bind_ip:integer)| 127.0.0.1:8000| The port number for web. If set to 0, no port is used.<br/>If you want to bind to any host IP different from the default 127.0.0.1, you can specify it with the bind_ip:port format (0.0.0.0 means bind to all) |
 | `MOODLE_DOCKER_SELENIUM_VNC_PORT`         | no        | any integer value (or bind_ip:integer)| not set       | If set, the selenium node will expose a vnc session on the port specified. Similar to MOODLE_DOCKER_WEB_PORT, you can optionally define the host IP to bind to. If you just set the port, VNC binds to 127.0.0.1 |
-| `MOODLE_APP_VERSION`                      | no        | next, latest, or an app version number| not set       | If set will start an instance of the Mmodle app if the chrome browser is selected |
+| `MOODLE_APP_VERSION`                      | no        | next, latest, or an app version number| not set       | If set will start an instance of the Moodle app if the chrome browser is selected |
 
 ## Using XDebug for live debugging
 

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -44,8 +44,12 @@ if [ -f $filename ]; then
     dockercompose="${dockercompose} -f ${filename}"
 fi
 
-# Mobile app
-if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_APP_VERSION" ]];
+# Mobile app for development
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_DOCKER_APP_PATH" ]];
+then
+    dockercompose="${dockercompose} -f ${basedir}/moodle-app-dev.yml"
+# Mobile app using a docker image
+elif [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_APP_VERSION" ]];
 then
     dockercompose="${dockercompose} -f ${basedir}/moodle-app.yml"
 fi

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -35,7 +35,9 @@ if exist %filename% (
 )
 
 IF "%MOODLE_DOCKER_BROWSER%"=="chrome" (
-    IF NOT "%MOODLE_APP_VERSION%"=="" (
+    IF NOT "%MOODLE_DOCKER_APP_PATH%"=="" (
+        SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\moodle-app-dev.yml"
+    ) ELSE IF NOT "%MOODLE_APP_VERSION%"=="" (
         SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\moodle-app.yml"
     )
 )

--- a/bin/moodle-docker-wait-for-app
+++ b/bin/moodle-docker-wait-for-app
@@ -3,7 +3,7 @@ set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_APP_VERSION" ]];
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && ([[ ! -z "$MOODLE_DOCKER_APP_PATH" ]] || [[ ! -z "$MOODLE_APP_VERSION" ]]);
 then
     until $basedir/bin/moodle-docker-compose logs moodleapp | grep -q 'dev server running: ';
     do

--- a/moodle-app-dev.yml
+++ b/moodle-app-dev.yml
@@ -1,0 +1,19 @@
+version: "2"
+services:
+  webserver:
+    environment:
+      MOODLE_DOCKER_APP: "true"
+  moodleapp:
+    image: node:11
+    working_dir: /app
+    command: npm run ionic:serve
+    volumes:
+      - "${MOODLE_DOCKER_APP_PATH}:/app"
+    expose:
+      - 8100
+      - 35729
+      - 53703
+    ports:
+      - "8100:8100"
+      - "35729:35729"
+      - "53703:53703"

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -12,6 +12,15 @@ elif [ "$SUITE" = "phpunit-full" ];
 then
     export MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES=true
     initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php"
+elif [ "$SUITE" = "behat-app-development" ];
+then
+    git clone --branch "v$APP_VERSION" --depth 1 git://github.com/moodlehq/moodleapp $HOME/app
+    git clone --branch "v$APP_VERSION" --depth 1 git://github.com/moodlehq/moodle-local_moodlemobileapp $HOME/moodle/local/moodlemobileapp
+
+    docker run --volume $HOME/app:/app --workdir /app node:11 npm install
+    docker run --volume $HOME/app:/app --workdir /app node:11 npm run setup
+
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
 elif [ "$SUITE" = "behat-app" ];
 then
     git clone --branch "v$APP_VERSION" --depth 1 git://github.com/moodlehq/moodle-local_moodlemobileapp $HOME/moodle/local/moodlemobileapp

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -12,8 +12,10 @@ elif [ "$SUITE" = "phpunit-full" ];
 then
     export MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES=true
     initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php"
-elif [ "$SUITE" = "app" ];
+elif [ "$SUITE" = "behat-app" ];
 then
+    git clone --branch "v$APP_VERSION" --depth 1 git://github.com/moodlehq/moodle-local_moodlemobileapp $HOME/moodle/local/moodlemobileapp
+
     initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
 else
     echo "Error, unknown suite '$SUITE'"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,9 +12,9 @@ then
 elif [ "$SUITE" = "phpunit-full" ];
 then
     testcmd="bin/moodle-docker-compose exec -T webserver vendor/bin/phpunit --verbose"
-elif [ "$SUITE" = "app" ];
+elif [ "$SUITE" = "behat-app" ];
 then
-    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags=@app"
+    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags='@app&&@mod_login'"
 else
     echo "Error, unknown suite '$SUITE'"
     exit 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -12,9 +12,9 @@ then
 elif [ "$SUITE" = "phpunit-full" ];
 then
     testcmd="bin/moodle-docker-compose exec -T webserver vendor/bin/phpunit --verbose"
-elif [ "$SUITE" = "behat-app" ];
+elif [ "$SUITE" = "behat-app" ] || [ "$SUITE" = "behat-app-development" ];
 then
-    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags='@app&&@mod_login'"
+    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags=@app&&@mod_login"
 else
     echo "Error, unknown suite '$SUITE'"
     exit 1


### PR DESCRIPTION
The current configuration runs the mobile app from docker images, and so it doesn't support using this for development.

With the modifications made in this PR, it's possible to configure a path to a local clone using the env variable `MOODLE_DOCKER_APP_PATH` (in the same way that a local clone of moodle is configured using `MOODLE_DOCKER_WWWROOT`).

~When I looked into the configuration I noticed that the previous env variable was called `MOODLE_APP_VERSION`, so I renamed it to `MOODLE_DOCKER_APP_VERSION` to keep the `MOODLE_DOCKER_` prefix. This is a breaking change, but considering that the variable was added recently it shouldn't affect too many developers. If this change is deemed too risky, I can undo it.~ --> Moved to a dedicated issue: #127.

I also noticed that app tests in Travis were running against the `next` image of the mobile app. I removed it because that image is too unstable (it's the development version). It may cause this project's CI to break if the development version's CI breaks, which isn't uncommon in a development branch. Testing with stable branches should be enough, like it's done for LMS tests.

~Finally, I had to bump the version of composer config to 2.3 in order to declare the [healthcheck](https://docs.docker.com/compose/compose-file/compose-file-v2/#healthcheck) in the app development config.~ --> Will be open in a different PR.