### PR TITLE
Rename MOODLE_APP_VERSION to MOODLE_DOCKER_APP_VERSION

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
     - export MOODLE_DOCKER_WWWROOT="$HOME/moodle"
     - export MOODLE_DOCKER_PHP_VERSION=$PHP
     - export MOODLE_DOCKER_APP_PATH=$APP_PATH
-    - export MOODLE_APP_VERSION=$APP_VERSION
+    - export MOODLE_DOCKER_APP_VERSION=$APP_VERSION
 before_script:
     - tests/setup.sh
 script:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ In order to run Behat tests for the mobile app, you need to install the [local_m
 
 The Behat tests will be run against a container serving the mobile application, you have two options here:
 
-1. Use a docker image that includes the application code. You need to specify the `MOODLE_APP_VERSION` env variable and the [moodlehq/moodleapp](https://hub.docker.com/r/moodlehq/moodleapp) image will be downloaded from docker hub.
+1. Use a docker image that includes the application code. You need to specify the `MOODLE_DOCKER_APP_VERSION` env variable and the [moodlehq/moodleapp](https://hub.docker.com/r/moodlehq/moodleapp) image will be downloaded from docker hub.
 
 2. Use a local copy of the application code and serve it through docker, similar to how the Moodle site is being served. Set the `MOODLE_DOCKER_APP_PATH` env variable to the codebase in you file system. This will assume that you've already initialized the app calling `npm install` and `npm run setup` locally.
 
@@ -179,7 +179,7 @@ You can change the configuration of the docker images by setting various environ
 | `MOODLE_DOCKER_WEB_PORT`                  | no        | any integer value (or bind_ip:integer)| 127.0.0.1:8000| The port number for web. If set to 0, no port is used.<br/>If you want to bind to any host IP different from the default 127.0.0.1, you can specify it with the bind_ip:port format (0.0.0.0 means bind to all) |
 | `MOODLE_DOCKER_SELENIUM_VNC_PORT`         | no        | any integer value (or bind_ip:integer)| not set       | If set, the selenium node will expose a vnc session on the port specified. Similar to MOODLE_DOCKER_WEB_PORT, you can optionally define the host IP to bind to. If you just set the port, VNC binds to 127.0.0.1 |
 | `MOODLE_DOCKER_APP_PATH`                  | no        | path on your file system              | not set       | If set and the chrome browser is selected, it will start an instance of the Moodle app from your local codebase |
-| `MOODLE_APP_VERSION`                      | no        | next, latest, or an app version number| not set       | If set will start an instance of the Moodle app if the chrome browser is selected |
+| `MOODLE_DOCKER_APP_VERSION`               | no        | next, latest, or an app version number| not set       | If set will start an instance of the Moodle app if the chrome browser is selected |
 
 ## Using XDebug for live debugging
 

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -44,12 +44,23 @@ if [ -f $filename ]; then
     dockercompose="${dockercompose} -f ${filename}"
 fi
 
+# Mobile app deprecated variables
+if [ ! -z "$MOODLE_APP_VERSION" ];
+then
+    echo 'Warning: $MOODLE_APP_VERSION is deprecated, use $MOODLE_DOCKER_APP_VERSION instead'
+
+    if [ -z "$MOODLE_DOCKER_APP_VERSION" ];
+    then
+        export MOODLE_DOCKER_APP_VERSION="$MOODLE_APP_VERSION"
+    fi
+fi
+
 # Mobile app for development
 if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_DOCKER_APP_PATH" ]];
 then
     dockercompose="${dockercompose} -f ${basedir}/moodle-app-dev.yml"
 # Mobile app using a docker image
-elif [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_APP_VERSION" ]];
+elif [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && [[ ! -z "$MOODLE_DOCKER_APP_VERSION" ]];
 then
     dockercompose="${dockercompose} -f ${basedir}/moodle-app.yml"
 fi

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -34,10 +34,18 @@ if exist %filename% (
     SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%filename%"
 )
 
+IF NOT "%MOODLE_APP_VERSION%"=="" (
+    ECHO Warning: MOODLE_APP_VERSION is deprecated, use MOODLE_DOCKER_APP_VERSION instead
+
+    IF "%MOODLE_DOCKER_APP_VERSION%"=="" (
+        SET MOODLE_DOCKER_APP_VERSION="%MOODLE_APP_VERSION%"
+    )
+)
+
 IF "%MOODLE_DOCKER_BROWSER%"=="chrome" (
     IF NOT "%MOODLE_DOCKER_APP_PATH%"=="" (
         SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\moodle-app-dev.yml"
-    ) ELSE IF NOT "%MOODLE_APP_VERSION%"=="" (
+    ) ELSE IF NOT "%MOODLE_DOCKER_APP_VERSION%"=="" (
         SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%BASEDIR%\moodle-app.yml"
     )
 )

--- a/bin/moodle-docker-wait-for-app
+++ b/bin/moodle-docker-wait-for-app
@@ -3,7 +3,7 @@ set -e
 
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
-if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && ([[ ! -z "$MOODLE_DOCKER_APP_PATH" ]] || [[ ! -z "$MOODLE_APP_VERSION" ]]);
+if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && ([[ ! -z "$MOODLE_DOCKER_APP_PATH" ]] || [[ ! -z "$MOODLE_DOCKER_APP_VERSION" ]] || [[ ! -z "$MOODLE_APP_VERSION" ]]);
 then
     until $basedir/bin/moodle-docker-compose logs moodleapp | grep -q 'dev server running: ';
     do

--- a/moodle-app.yml
+++ b/moodle-app.yml
@@ -4,4 +4,4 @@ services:
     environment:
       MOODLE_DOCKER_APP: "true"
   moodleapp:
-    image: "moodlehq/moodleapp:${MOODLE_APP_VERSION}"
+    image: "moodlehq/moodleapp:${MOODLE_DOCKER_APP_VERSION}"


### PR DESCRIPTION
As mentioned in #127, the variable `MOODLE_APP_VERSION` does not follow the standard `MOODLE_DOCKER_` prefix.

Besides renaming it, I've added a warning that handles backwards compatibility.