### PR TITLE
Define some helpful config flags for running tasks.

### DIFF
--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -40,6 +40,8 @@ $CFG->perfdebug = 15;
 $CFG->debugpageinfo = 1;
 $CFG->allowthemechangeonurl = 1;
 $CFG->passwordpolicy = 0;
+$CFG->cronclionly = 0;
+$CFG->pathtophp = '/usr/local/bin/php';
 
 $CFG->phpunit_dataroot  = '/var/www/phpunitdata';
 $CFG->phpunit_prefix = 't_';


### PR DESCRIPTION
They allow cron/tasks to be run immediately through the UI without additional configuration.