### PR TITLE
Set wait-timeout to proper default (28800)

### DIFF
--- a/db.mariadb.yml
+++ b/db.mariadb.yml
@@ -10,6 +10,7 @@ services:
               --character-set-server=utf8mb4
               --collation-server=utf8mb4_bin
               --innodb_file_per_table=On
+              --wait-timeout=28800
     environment:
       MYSQL_ROOT_PASSWORD: "m@0dl3ing"
       MYSQL_USER: moodle


### PR DESCRIPTION
Older (than 10.5) MariaDB docker containers come
with wait-timeout = 600 and that makes unit tests
execution to fail with "MySQL is gone away".

Apparently this is already ok with current 10.5
so current moodle-docker instances are passing ok
without needing the setting

But, no matter of that, we are explicitly adding
the setting here, to enable anybody wanting to use
older MariaDB docker images to get tests passing.

See https://tracker.moodle.org/browse/MDLSITE-6141
for more details.

If you want to verify that the setting added is in effect, just:

1. Edit the `db.mariadb.yml`file and force the image to older version (aka: `image: mariadb:10.2`).
2. Setup moodle-docker to start the composition with mariadb.
3. SSH into the mariadb container
4. run mysql (user and password are in the `db.mariadb.yml`
5. Execute `SHOW global VARIABLES LIKE 'wait_timeout';`
6. You should see the value is now 28800 (without the PR, it's 600).