### PR TITLE
Fix app setup script for old releases

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -17,8 +17,8 @@ then
     git clone --branch "v$APP_VERSION" --depth 1 git://github.com/moodlehq/moodleapp $HOME/app
     git clone --branch "v$APP_VERSION" --depth 1 git://github.com/moodlehq/moodle-local_moodlemobileapp $HOME/moodle/local/moodlemobileapp
 
-    docker run --volume $HOME/app:/app --workdir /app node:11 npm install
     docker run --volume $HOME/app:/app --workdir /app node:11 npm run setup
+    docker run --volume $HOME/app:/app --workdir /app node:11 npm ci
 
     initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
 elif [ "$SUITE" = "behat-app" ];


### PR DESCRIPTION
For older versions of the app, `npm install` incorrectly updates some unversioned packages (instead of using the commit indicated in package-lock.json). In order to fix that, we just need to run `npm ci` after setting up the application. I've also removed the `npm install` before calling `npm run setup` because it was redundant.