### PR TITLE
Login in dockerhub when possible to avoid pull limits

### DIFF
--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -2,6 +2,14 @@
 set -e
 basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
 
+# Log in dockerhub if possible (to avoid pull limits for unauthenticated uses).
+if [ -n "$DOCKER_USER" ] && [ -n "$DOCKER_TOKEN" ]; then
+    echo "$DOCKER_TOKEN" | docker login -u "$DOCKER_USER" --password-stdin
+    echo "Using authenticated connection (no pull limits)"
+else
+    echo "Using unauthenticated docker (pull limits may apply). Setup DOCKER_USER and DOCKER_TOKEN if needed."
+fi
+
 if [ "$SUITE" = "phpunit" ];
 then
     initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php"


### PR DESCRIPTION
With current pull limits @ dockerhub, it's possible to get failed
jobs just running 2-3 builds (each one having a good number of jobs).
    
With this patch, if both DOCKER_USER and DOCKER_TOKEN are defined
as environmental variables, they will be used to perform a login
to dockerhub, getting rid of pull limits.

