### PR TITLE
Document site summary argument in installation script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Notes:
 
 ```bash
 # Initialize Moodle database for manual testing
-bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --adminpass="test" --adminemail="admin@example.com"
+bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --summary="Docker moodle site" --adminpass="test" --adminemail="admin@example.com"
 ```
 
 Notes:


### PR DESCRIPTION
Available since MDL-70643 (ignored in prior versions), fixes #121.