### PR TITLE
Add GHA support to moodle-docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,183 @@
+name: moodle-docker CI
+
+on: [push, pull_request]
+
+jobs:
+  PHPUnit:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PostgreSQL (highest, lowest php supported)
+          - { branch: master,            php: "8.0", database: pgsql, suite: phpunit-full } # Full run only for mater.
+          - { branch: master,            php: "7.3", database: pgsql, suite: phpunit-full }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: pgsql, suite: phpunit } # Other branches, quicker run.
+          - { branch: MOODLE_311_STABLE, php: "7.3", database: pgsql, suite: phpunit }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: pgsql, suite: phpunit }
+          - { branch: MOODLE_310_STABLE, php: "7.2", database: pgsql, suite: phpunit }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: pgsql, suite: phpunit }
+          - { branch: MOODLE_39_STABLE,  php: "7.2", database: pgsql, suite: phpunit }
+          # MariaDB (lowest php supported)
+          - { branch: master,            php: "7.3", database: mariadb, suite: phpunit }
+          - { branch: MOODLE_311_STABLE, php: "7.3", database: mariadb, suite: phpunit }
+          - { branch: MOODLE_310_STABLE, php: "7.2", database: mariadb, suite: phpunit }
+          - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, suite: phpunit }
+          # Other databases (highest php supported)
+          - { branch: master,            php: "8.0", database: mssql,  suite: phpunit }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: mssql,  suite: phpunit }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  suite: phpunit }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  suite: phpunit }
+          - { branch: master,            php: "8.0", database: mysql,  suite: phpunit }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: mysql,  suite: phpunit }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  suite: phpunit }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  suite: phpunit }
+          - { branch: master,            php: "8.0", database: oracle, suite: phpunit }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: oracle, suite: phpunit }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: oracle, suite: phpunit }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: oracle, suite: phpunit }
+
+    steps:
+      - name: Checking out moodle-docker
+        uses: actions/checkout@v2
+
+      - name: Checking out moodle
+        uses: actions/checkout@v2
+        with:
+          repository: moodle/moodle
+          path: moodle
+          ref: ${{ matrix.branch }}
+
+      - name: Prepare moodle-docker environment
+        run: |
+          cp config.docker-template.php moodle/config.php
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export MOODLE_DOCKER_PHP_VERSION="${{ matrix.php }}"
+          export SUITE="${{ matrix.suite }}"
+          tests/phpunit-setup.sh
+
+      - name: Run moodle-docker tests
+        run: |
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export SUITE="${{ matrix.suite }}"
+          tests/phpunit-test.sh
+
+      - name: Stop moodle-docker
+        run: |
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export SUITE="${{ matrix.suite }}"
+          tests/phpunit-teardown.sh
+
+  Behat:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PostgreSQL (highest, lowest php supported)
+          - { branch: master,            php: "8.0", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: master,            php: "7.3", database: pgsql, browser: firefox, suite: behat }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: MOODLE_311_STABLE, php: "7.3", database: pgsql, browser: firefox, suite: behat }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: MOODLE_310_STABLE, php: "7.2", database: pgsql, browser: firefox, suite: behat }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: MOODLE_39_STABLE,  php: "7.2", database: pgsql, browser: firefox, suite: behat }
+          # MariaDB (lowest php supported)
+          - { branch: master,            php: "7.3", database: mariadb, browser: chrome,  suite: behat }
+          - { branch: MOODLE_311_STABLE, php: "7.3", database: mariadb, browser: firefox, suite: behat }
+          - { branch: MOODLE_310_STABLE, php: "7.2", database: mariadb, browser: chrome,  suite: behat }
+          - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, browser: firefox, suite: behat }
+          # Other databases (highest php supported")
+          - { branch: master,            php: "8.0", database: mssql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: mssql,  browser: firefox, suite: behat }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  browser: firefox, suite: behat }
+          - { branch: master,            php: "8.0", database: mysql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: mysql,  browser: firefox, suite: behat }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  browser: firefox, suite: behat }
+          - { branch: master,            php: "8.0", database: oracle, browser: chrome,  suite: behat }
+          - { branch: MOODLE_311_STABLE, php: "8.0", database: oracle, browser: firefox, suite: behat }
+          - { branch: MOODLE_310_STABLE, php: "7.4", database: oracle, browser: chrome,  suite: behat }
+          - { branch: MOODLE_39_STABLE,  php: "7.4", database: oracle, browser: firefox, suite: behat }
+
+    steps:
+      - name: Checking out moodle-docker
+        uses: actions/checkout@v2
+
+      - name: Checking out moodle
+        uses: actions/checkout@v2
+        with:
+          repository: moodle/moodle
+          path: moodle
+          ref: ${{ matrix.branch }}
+
+      - name: Prepare moodle-docker environment
+        run: |
+          cp config.docker-template.php moodle/config.php
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export MOODLE_DOCKER_PHP_VERSION="${{ matrix.php }}"
+          export SUITE="${{ matrix.suite }}"
+          export MOODLE_DOCKER_BROWSER="${{ matrix.browser }}"
+          tests/behat-setup.sh
+
+      - name: Run moodle-docker tests
+        run: |
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export SUITE="${{ matrix.suite }}"
+          tests/behat-test.sh
+
+      - name: Stop moodle-docker
+        run: |
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export SUITE="${{ matrix.suite }}"
+          tests/behat-teardown.sh
+
+  App:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # PostgreSQL (highest, lowest php supported)
+          - { branch: master, php: "8.0", database: pgsql, suite: app-development, app-version: "3.9.0"}
+          - { branch: master, php: "7.3", database: pgsql, suite: app-development, app-version: "3.9.0"}
+          - { branch: master, php: "8.0", database: pgsql, suite: app, app-version: "3.9.0"}
+          - { branch: master, php: "7.3", database: pgsql, suite: app, app-version: "3.9.0"}
+
+    steps:
+      - name: Checking out moodle-docker
+        uses: actions/checkout@v2
+
+      - name: Checking out moodle
+        uses: actions/checkout@v2
+        with:
+          repository: moodle/moodle
+          path: moodle
+          ref: ${{ matrix.branch }}
+
+      - name: Prepare moodle-docker environment
+        run: |
+          cp config.docker-template.php moodle/config.php
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export MOODLE_DOCKER_PHP_VERSION="${{ matrix.php }}"
+          export SUITE="${{ matrix.suite }}"
+          export MOODLE_DOCKER_APP_VERSION="${{ matrix.app-version }}"
+          tests/app-setup.sh
+
+      - name: Run moodle-docker tests
+        run: |
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export SUITE="${{ matrix.suite }}"
+          tests/app-test.sh
+
+      - name: Stop moodle-docker
+        run: |
+          export MOODLE_DOCKER_DB="${{ matrix.database }}"
+          export SUITE="${{ matrix.suite }}"
+          export MOODLE_DOCKER_APP_VERSION="${{ matrix.app-version }}"
+          tests/app-teardown.sh

--- a/bin/moodle-docker-wait-for-db
+++ b/bin/moodle-docker-wait-for-db
@@ -20,5 +20,5 @@ then
         sleep 15
     done
 else
-    sleep 5
+    sleep 10
 fi

--- a/tests/app-setup.sh
+++ b/tests/app-setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+export MOODLE_DOCKER_BROWSER="chrome"
+
+if [ "$SUITE" = "app-development" ];
+then
+    export MOODLE_DOCKER_APP_PATH="${basedir}/app"
+    git clone --branch "v$MOODLE_DOCKER_APP_VERSION" --depth 1 git://github.com/moodlehq/moodleapp $basedir/app
+    git clone --branch "v$MOODLE_DOCKER_APP_VERSION" --depth 1 git://github.com/moodlehq/moodle-local_moodlemobileapp $basedir/moodle/local/moodlemobileapp
+
+    docker run --volume $basedir/app:/app --workdir /app node:11 npm run setup
+    docker run --volume $basedir/app:/app --workdir /app node:11 npm ci
+
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
+elif [ "$SUITE" = "app" ];
+then
+    git clone --branch "v$MOODLE_DOCKER_APP_VERSION" --depth 1 git://github.com/moodlehq/moodle-local_moodlemobileapp $basedir/moodle/local/moodlemobileapp
+
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Pulling docker images"
+$basedir/bin/moodle-docker-compose pull
+echo "Starting up container"
+$basedir/bin/moodle-docker-compose up -d
+echo "Waiting for DB to come up"
+$basedir/bin/moodle-docker-wait-for-db
+echo "Waiting for Moodle app to come up"
+$basedir/bin/moodle-docker-wait-for-app
+echo "Running: $initcmd"
+$basedir/$initcmd

--- a/tests/app-teardown.sh
+++ b/tests/app-teardown.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+export MOODLE_DOCKER_BROWSER="chrome"
+
+if [ "$SUITE" = "app-development" ];
+then
+    export MOODLE_DOCKER_APP_PATH="${basedir}/app"
+elif [ "$SUITE" = "app" ];
+then
+    echo
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Stopping down container"
+$basedir/bin/moodle-docker-compose down

--- a/tests/app-test.sh
+++ b/tests/app-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "app" ] || [ "$SUITE" = "app-development" ];
+then
+    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags=@app&&@mod_login"
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Running: $testcmd"
+$basedir/$testcmd

--- a/tests/behat-setup.sh
+++ b/tests/behat-setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "behat" ];
+then
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/init.php"
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Pulling docker images"
+$basedir/bin/moodle-docker-compose pull
+echo "Starting up container"
+$basedir/bin/moodle-docker-compose up -d
+echo "Waiting for DB to come up"
+$basedir/bin/moodle-docker-wait-for-db
+echo "Running: $initcmd"
+$basedir/$initcmd

--- a/tests/behat-teardown.sh
+++ b/tests/behat-teardown.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "behat" ];
+then
+    echo
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Stopping down container"
+$basedir/bin/moodle-docker-compose down

--- a/tests/behat-test.sh
+++ b/tests/behat-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "behat" ];
+then
+    testcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/behat/cli/run.php --tags=@auth_manual"
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Running: $testcmd"
+$basedir/$testcmd

--- a/tests/phpunit-setup.sh
+++ b/tests/phpunit-setup.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -e
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "phpunit" ];
+then
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php"
+elif [ "$SUITE" = "phpunit-full" ];
+then
+    export MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES=true
+    initcmd="bin/moodle-docker-compose exec -T webserver php admin/tool/phpunit/cli/init.php"
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Pulling docker images"
+$basedir/bin/moodle-docker-compose pull
+echo "Starting up container"
+$basedir/bin/moodle-docker-compose up -d
+echo "Waiting for DB to come up"
+$basedir/bin/moodle-docker-wait-for-db
+echo "Running: $initcmd"
+$basedir/$initcmd

--- a/tests/phpunit-teardown.sh
+++ b/tests/phpunit-teardown.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "phpunit" ];
+then
+    echo
+elif [ "$SUITE" = "phpunit-full" ];
+then
+    export MOODLE_DOCKER_PHPUNIT_EXTERNAL_SERVICES=true
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Stopping down container"
+$basedir/bin/moodle-docker-compose down

--- a/tests/phpunit-test.sh
+++ b/tests/phpunit-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+if [ "$SUITE" = "phpunit" ];
+then
+    testcmd="bin/moodle-docker-compose exec -T webserver vendor/bin/phpunit --filter core_dml_testcase"
+elif [ "$SUITE" = "phpunit-full" ];
+then
+    testcmd="bin/moodle-docker-compose exec -T webserver vendor/bin/phpunit --verbose"
+else
+    echo "Error, unknown suite '$SUITE'"
+    exit 1
+fi
+
+echo "Running: $testcmd"
+$basedir/$testcmd


### PR DESCRIPTION
Basically does the same than old Travis runs, with some differences:

- I've grouped the jobs into 3 categories (phpunit, behat, app).
- Each one has own setup/teardown/test shell script, instead of the
  previous "mammoth" setup and test scripts, that I've left unmodified
- Aiming to get the travis CI runs disabled because they are super slow
  (we only have 2 concurrent jobs allowed) and, while running, all the
  other moodlehq repos have to wait.
- I'll create an issue to remove travis support once this
  is accepted and working ok.
- Only change that I had to perform to existing stuff is raising the
  hardcoded sleep of 5 seconds to 10 seconds because I was getting some
  random failures with MySQL, needing more time to start.
- We should move to proper health-checks for database (#160) containers soon,
  much like app containers (#131).