### PR TITLE
Make mariadb:10.5 sticky

### DIFF
--- a/db.mariadb.yml
+++ b/db.mariadb.yml
@@ -5,7 +5,7 @@ services:
       MOODLE_DOCKER_DBTYPE: mariadb
       MOODLE_DOCKER_DBCOLLATION: utf8mb4_bin
   db:
-    image: mariadb:10
+    image: mariadb:10.5
     command: >
               --character-set-server=utf8mb4
               --collation-server=utf8mb4_bin


### PR DESCRIPTION
New mariadb:10.6 makes the COMPRESSED row format read-only by default
because it's deprecated now and will be removed in mariadb:10.7

This is being tracked @ https://tracker.moodle.org/browse/MDL-72131

Once that issue is fixed and we switch to DYNAMIC or whichever the
final solution is, we'll unpin this.