### PR TITLE
Bind exttests to port 9000 to support podman-compose

### DIFF
--- a/assets/exttests/apache2.conf
+++ b/assets/exttests/apache2.conf
@@ -1,0 +1,31 @@
+<VirtualHost *:9000>
+	# The ServerName directive sets the request scheme, hostname and port that
+	# the server uses to identify itself. This is used when creating
+	# redirection URLs. In the context of virtual hosts, the ServerName
+	# specifies what hostname must appear in the request's Host: header to
+	# match this virtual host. For the default virtual host (this file) this
+	# value is not decisive as it is used as a last resort host regardless.
+	# However, you must set it for any further virtual host explicitly.
+	#ServerName www.example.com
+
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+
+	# Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+	# error, crit, alert, emerg.
+	# It is also possible to configure the loglevel for particular
+	# modules, e.g.
+	#LogLevel info ssl:warn
+
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	# For most configuration files from conf-available/, which are
+	# enabled or disabled at a global level, it is possible to
+	# include a line for only one particular virtual host. For example the
+	# following line enables the CGI configuration for this host only
+	# after it has been globally disabled with "a2disconf".
+	#Include conf-available/serve-cgi-bin.conf
+</VirtualHost>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/assets/exttests/apache2_ports.conf
+++ b/assets/exttests/apache2_ports.conf
@@ -1,0 +1,15 @@
+# If you just change the port or add more ports here, you will likely also
+# have to change the VirtualHost statement in
+# /etc/apache2/sites-enabled/000-default.conf
+
+Listen 9000
+
+<IfModule ssl_module>
+	Listen 9443
+</IfModule>
+
+<IfModule mod_gnutls.c>
+	Listen 9443
+</IfModule>
+
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/base.yml
+++ b/base.yml
@@ -22,6 +22,9 @@ services:
       POSTGRES_DB: moodle
   exttests:
     image: moodlehq/moodle-exttests
+    volumes:
+      - "${ASSETDIR}/exttests/apache2_ports.conf:/etc/apache2/ports.conf"
+      - "${ASSETDIR}/exttests/apache2.conf:/etc/apache2/sites-enabled/000-default.conf"
   selenium:
     image: "selenium/standalone-firefox${MOODLE_DOCKER_SELENIUM_SUFFIX}:2.53.1"
     volumes:

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -46,7 +46,7 @@ $CFG->pathtophp = '/usr/local/bin/php';
 
 $CFG->phpunit_dataroot  = '/var/www/phpunitdata';
 $CFG->phpunit_prefix = 't_';
-define('TEST_EXTERNAL_FILES_HTTP_URL', 'http://exttests');
+define('TEST_EXTERNAL_FILES_HTTP_URL', 'http://exttests:9000');
 
 $CFG->behat_wwwroot   = 'http://webserver';
 $CFG->behat_dataroot  = '/var/www/behatdata';


### PR DESCRIPTION
Provides necessary changes as requested and provided in #172.