### PR TITLE
Use NFS for Mac users

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ export MOODLE_DOCKER_DB=pgsql
 # Ensure customized config.php for the Docker containers is in place
 cp config.docker-template.php $MOODLE_DOCKER_WWWROOT/config.php
 
+# [..] IMPORTANT: For Mac users see next point
+
 # Start up containers
 bin/moodle-docker-compose up -d
 
@@ -39,6 +41,21 @@ bin/moodle-docker-wait-for-db
 # Shut down and destroy containers
 bin/moodle-docker-compose down
 ```
+
+### Mac users
+Docker is known to be really slow for Mac users. Run the next commands to fix that using NFS.
+
+```bash
+# [..] Follow the "Quick start" step until the "IMPORTANT" note. Then continue with this commands
+# This script will set up a NFS link between your $MOODLE_DOCKER_WWWROOT and the containers
+# We change the permissions of the script to be able to execute it
+chmod +x bin/nfs-script.sh
+# Now we run the script
+./bin/nfs-script.sh
+
+# [..] Continue with the "Quick start" from after the "IMPORTANT" note
+```
+
 ## Run several Moodle instances
 
 By default, the script will load a single instance. If you want to run two

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -109,7 +109,9 @@ fi
 # Mac OS Compatbility
 if [[ "$(uname)" == "Darwin" ]]; then
     # Support https://docs.docker.com/docker-for-mac/osxfs-caching/
-    dockercompose="${dockercompose} -f ${basedir}/volumes-cached.yml"
+    #dockercompose="${dockercompose} -f ${basedir}/volumes-cached.yml"
+    # https://vivait.co.uk/labs/docker-for-mac-performance-using-nfs
+    dockercompose="${dockercompose} -f ${basedir}/volumes-nfs.yml"
 fi
 
 

--- a/bin/nfs-script.sh
+++ b/bin/nfs-script.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+OS=`uname -s`
+
+if [ $OS != "Darwin" ]; then
+  echo "This script is OSX-only. Please do not run it on any other Unix."
+  exit 1
+fi
+
+if [[ $EUID -eq 0 ]]; then
+  echo "This script must NOT be run with sudo/root. Please re-run without sudo." 1>&2
+  exit 1
+fi
+
+echo ""
+echo " +-----------------------------+"
+echo " | Setup native NFS for Docker |"
+echo " +-----------------------------+"
+echo ""
+
+echo "WARNING: This script will shut down running containers."
+echo ""
+echo -n "Do you wish to proceed? [y]: "
+read decision
+
+if [ "$decision" != "y" ]; then
+  echo "Exiting. No changes made."
+  exit 1
+fi
+
+echo ""
+
+if ! docker ps > /dev/null 2>&1 ; then
+  echo "== Waiting for docker to start..."
+fi
+
+open -a Docker
+
+while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+echo "== Stopping running docker containers..."
+docker-compose down > /dev/null 2>&1
+docker volume prune -f > /dev/null
+
+osascript -e 'quit app "Docker"'
+
+echo "== Resetting folder permissions..."
+U=`id -u`
+G=`id -g`
+sudo chown -R "$U":"$G" .
+
+echo "== Setting up nfs..."
+# LINE="/Users -alldirs -mapall=$U:$G localhost"
+LINE="/System/Volumes/Data -alldirs -mapall=$U:$G localhost"
+FILE=/etc/exports
+sudo cp /dev/null $FILE
+grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+
+LINE="nfs.server.mount.require_resv_port = 0"
+FILE=/etc/nfs.conf
+grep -qF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+
+echo "== Restarting nfsd..."
+sudo nfsd restart
+
+echo "== Restarting docker..."
+open -a Docker
+
+while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+echo ""
+echo "SUCCESS! Now go run your containers"

--- a/volumes-nfs.yml
+++ b/volumes-nfs.yml
@@ -1,0 +1,14 @@
+# Here we support https://vivait.co.uk/labs/docker-for-mac-performance-using-nfs
+# for improved performance on mac
+version: "2"
+services:
+  webserver:
+    volumes:
+        - "nfsmount:/var/www/html"
+volumes:
+  nfsmount:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: ":/System/Volumes/Data/${MOODLE_DOCKER_WWWROOT}"


### PR DESCRIPTION
Docker is very slow for mac users (mainly when installing the db from scratch or setting up behat and phpunit and running them).
To fix that, we are able to use NFS. This PR uses NFS for Mac users instead of the old `:cached`.

Source: https://vivait.co.uk/labs/docker-for-mac-performance-using-nfs