### PR TITLE
Use exttests both for http and https

### DIFF
--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -47,6 +47,7 @@ $CFG->pathtophp = '/usr/local/bin/php';
 $CFG->phpunit_dataroot  = '/var/www/phpunitdata';
 $CFG->phpunit_prefix = 't_';
 define('TEST_EXTERNAL_FILES_HTTP_URL', 'http://exttests:9000');
+define('TEST_EXTERNAL_FILES_HTTPS_URL', 'http://exttests:9000');
 
 $CFG->behat_wwwroot   = 'http://webserver';
 $CFG->behat_dataroot  = '/var/www/behatdata';


### PR DESCRIPTION
It was promised @ #200 to fix #178, so here it is the fix.

Basically, without needing to put the exttests container with
a proper https configuration at all, use the existing http one
for the tests requiring https (because it's not checked).

We use the very same trick @ CIs and they are working and
running all the tests without a problem.

Fixes #178