### PR TITLE
Use Compose v2 if it is available in the system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains Docker configuration aimed at Moodle developers and tes
 * Backed by [automated tests](https://travis-ci.com/moodlehq/moodle-docker/branches)
 
 ## Prerequisites
-* [Docker](https://docs.docker.com) and [Docker Compose](https://docs.docker.com/compose/) installed
+* [Docker](https://docs.docker.com) and [Docker Compose](https://docs.docker.com/compose/cli-command/#installing-compose-v2) installed if your Docker CLI version does not support `docker compose` command.
 * 3.25GB of RAM (if you choose [Microsoft SQL Server](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup#prerequisites) as db server)
 
 ## Quick start
@@ -258,8 +258,8 @@ moodle-docker-compose restart webserver
 ## Advanced usage
 
 As can be seen in [bin/moodle-docker-compose](https://github.com/moodlehq/moodle-docker/blob/master/bin/moodle-docker-compose),
-this repo is just a series of docker-compose configurations and light wrapper which make use of companion docker images. Each part
-is designed to be reusable and you are encouraged to use the docker[-compose] commands as needed.
+this repo is just a series of Docker Compose configurations and light wrapper which make use of companion docker images. Each part
+is designed to be reusable and you are encouraged to use the docker [compose] commands as needed.
 
 ## Companion docker images
 

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -24,8 +24,15 @@ done
 basedir="$( cd -P "$( dirname "$SOURCE" )/../" && pwd )"
 export ASSETDIR="${basedir}/assets"
 
-
-dockercompose="docker-compose -f ${basedir}/base.yml"
+# Test if we have docker compose v2, and keep quiet if we don't.
+ver=$(docker compose version > /dev/null 2>&1 && docker compose version --short) || true
+if [[ $ver =~ ^v2 ]]; then
+  dockercompose="docker compose"
+else
+  echo 'Compose v2 is not available in Docker CLI, falling back to use docker-compose script'
+  dockercompose="docker-compose"
+fi
+dockercompose="${dockercompose} -f ${basedir}/base.yml"
 dockercompose="${dockercompose} -f ${basedir}/service.mail.yml"
 
 # PHP Version.


### PR DESCRIPTION
No changes to windows script as they seem maintaining alias which is using 'docker compose' insternally, given there is an option to disable v2 behavior by calling `docker-compose disable-v2` (https://docs.docker.com/compose/cli-command/#install-on-mac-and-windows), so for now it is fine to use it as is.

Fixes #202