### PR TITLE
Unpin MariaDB

### DIFF
--- a/db.mariadb.yml
+++ b/db.mariadb.yml
@@ -5,7 +5,7 @@ services:
       MOODLE_DOCKER_DBTYPE: mariadb
       MOODLE_DOCKER_DBCOLLATION: utf8mb4_bin
   db:
-    image: mariadb:10.5
+    image: mariadb:10
     command: >
               --character-set-server=utf8mb4
               --collation-server=utf8mb4_bin


### PR DESCRIPTION
Now that 10.6.7 and 10.7.3 have been releases and their
docker images are available, we can unpin it @ GHA.

Fixes #174