### PR TITLE
Update Moodle Docker Compose V2 Check

### DIFF
--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -26,7 +26,7 @@ export ASSETDIR="${basedir}/assets"
 
 # Test if we have docker compose v2, and keep quiet if we don't.
 ver=$(docker compose version > /dev/null 2>&1 && docker compose version --short) || true
-if [[ $ver =~ ^v2 ]]; then
+if [[ $ver =~ ^v?2 ]]; then
   dockercompose="docker compose"
 else
   echo 'Compose v2 is not available in Docker CLI, falling back to use docker-compose script'


### PR DESCRIPTION
This makes the `v` prefix optional in checks against the return value of `docker compose version --short` as it was removed in recent versions. e.g. The expected output was `v2.2.3` but is now simply `2.6.0`.

Closes #215.