### PR TITLE
Verify oracle availability using "DATABASE IS READY TO USE!"

### DIFF
--- a/bin/moodle-docker-wait-for-db
+++ b/bin/moodle-docker-wait-for-db
@@ -14,7 +14,7 @@ then
     $basedir/bin/moodle-docker-compose exec -T db /wait-for-mssql-to-come-up.sh
 elif [ "$MOODLE_DOCKER_DB" = "oracle" ];
 then
-    until $basedir/bin/moodle-docker-compose logs db | grep -q 'Database opened.';
+    until $basedir/bin/moodle-docker-compose logs db | grep -q 'DATABASE IS READY TO USE!';
     do
         echo 'Waiting for oracle to come up...'
         sleep 15


### PR DESCRIPTION
We have ensured that all the oracle database images output
at the end of the init script the "DATABASE IS READY TO USE!"
text. That has been done by:

https://github.com/moodlehq/moodle-db-oracle/pull/13

(Because Oracle 11g was missing that string)

So, now that the string is available in all moodle-db-oracle
images we can start using it here, in moodle-docker.

Still note this is not the ideal wait/health-check system
and we'll have to move to a proper one. See:

https://github.com/moodlehq/moodle-docker/issues/160

But it's better than nothing, and the current one based
on the "Database opened." string was not working ok for
Oracle 21c (that requires 2 startups).