### PR TITLE
Bump GHA environments to use Ubuntu 22.04 (up from 18.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   PHPUnit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -76,7 +76,7 @@ jobs:
           tests/phpunit-teardown.sh
 
   Behat:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
@@ -149,7 +149,7 @@ jobs:
           tests/behat-teardown.sh
 
   App:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Since some time ago, GH is warning us that the Ubuntu 18.04 environment is deprecated:

"The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead...."

Hence, we are bumping here, to be able to cerify if everything continues working ok