### PR TITLE
simplify basedir variable setting

### DIFF
--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# First find out if this was called from symlink,
+# then find the real path of parent directory.
+# This is needed because macOS does not have GNU realpath.
+thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
+basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
+
 if [ ! -d "$MOODLE_DOCKER_WWWROOT" ];
 then
     echo 'Error: $MOODLE_DOCKER_WWWROOT is not set or not an existing directory'
@@ -13,15 +19,6 @@ then
     exit 1
 fi
 
-# Nasty portable way to the directory of this script, following symlink,
-# because readlink -f not on OSX. Thanks stack overflow..
-SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
-  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-  SOURCE="$(readlink "$SOURCE")"
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
-done
-basedir="$( cd -P "$( dirname "$SOURCE" )/../" && pwd )"
 export ASSETDIR="${basedir}/assets"
 
 # Test if we have docker compose v2, and keep quiet if we don't.

--- a/bin/moodle-docker-wait-for-app
+++ b/bin/moodle-docker-wait-for-app
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
+basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
 
 if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && ([[ ! -z "$MOODLE_DOCKER_APP_PATH" ]] || [[ ! -z "$MOODLE_DOCKER_APP_VERSION" ]] || [[ ! -z "$MOODLE_APP_VERSION" ]]);
 then

--- a/bin/moodle-docker-wait-for-db
+++ b/bin/moodle-docker-wait-for-db
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
+basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
 
 if [ -z "$MOODLE_DOCKER_DB" ];
 then


### PR DESCRIPTION
I had trouble understanding the magic behind current basedir logic, so I invented a simpler version. It expects that only the executables from bin/* are symlinked or the whole moodle-docker. Symlinking just the bin directory does not make sense to me, they should just add the bin/ to their search path most likely instead.

I will be be using basedir it future patches, the current one seems to be a bit too long to copy/paste into all those other scripts such as waiting for db and app.

I can confirm it works fine in macOS and linux.