### PR TITLE
Add support for ./moodle-docker.env

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,36 @@ to the instance you expect to. See
 [envvars](https://docs.docker.com/compose/reference/envvars/)
 to see more about `docker-compose` environment variables.
 
+## Environment setting defaults via ./moodle-docker.env
+
+In Linux and macOS it is also possible to created `moodle-docker.env` file
+in directory where `bin/moodle-docker-compose` is executed, the file contents are
+then used as default environment values.
+
+If `moodle-docker.env` is in Moodle code root, then MOODLE_DOCKER_WWWROOT default
+is set to Moodle directory and COMPOSE_PROJECT_NAME defaults to Moodle directory name.
+
+Example:
+
+1. Create `/path/to/moodle/moodle-docker.env` file with the following content:
+```
+# file location /path/to/moodle/moodle-docker.env
+MOODLE_DOCKER_DB=pgsql
+```
+2. Copy config.docker-template.php file to `/path/to/moodle/config.php`
+3. Start containers:
+```bash
+cd /path/to/moodle
+/path/to/moodle-docker/bin/moodle-docker-compose up -d
+```
+4. Switch to MariaDB temporarily:
+```bash
+cd /path/to/moodle
+/path/to/moodle-docker/bin/moodle-docker-compose down
+export MOODLE_DOCKER_DB=mariadb
+/path/to/moodle-docker/bin/moodle-docker-compose up -d
+```
+
 ## Use containers for running behat tests
 
 ```bash

--- a/bin/include/env.cmd
+++ b/bin/include/env.cmd
@@ -1,0 +1,28 @@
+@ECHO OFF
+
+IF EXIST "moodle-docker.env" (
+    FOR /F "usebackq tokens=1* delims== eol=#" %%i IN (moodle-docker.env) DO (
+        IF NOT DEFINED %%i (
+           SET %%i=%%j
+        )
+    )
+
+    IF EXIST "lib/moodlelib.php" (
+        IF "%MOODLE_DOCKER_WWWROOT%"=="" (
+            SET MOODLE_DOCKER_WWWROOT=%cd%
+        )
+        IF "%COMPOSE_PROJECT_NAME%"=="" (
+            FOR %%* IN (.) DO SET COMPOSE_PROJECT_NAME=%%~nx*
+        )
+    )
+)
+
+IF NOT EXIST "%MOODLE_DOCKER_WWWROOT%" (
+    ECHO Error: MOODLE_DOCKER_WWWROOT is not set or not an existing directory
+    EXIT /B 1
+)
+
+IF "%MOODLE_DOCKER_DB%"=="" (
+    ECHO Error: MOODLE_DOCKER_DB is not set
+    EXIT /B 1
+)

--- a/bin/include/env.sh
+++ b/bin/include/env.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# If moodle-docker.env file found then use it as default environment values.
+filename="moodle-docker.env"
+if [ -f $filename ]; then
+    envbackup=$( export -p)
+    export $(grep -v '^#' $filename | xargs)
+    eval "$envbackup"
+    if [ -z "$MOODLE_DOCKER_WWWROOT" ] && [ -f 'lib/moodlelib.php' ];
+    then
+        # We know that moodle is in current directory, so use it as default value.
+        currentdir="$( pwd -P )";
+        export MOODLE_DOCKER_WWWROOT="$currentdir";
+    fi
+    if [ -z "$COMPOSE_PROJECT_NAME" ] && [ -f 'lib/moodlelib.php' ];
+    then
+        # Use moodle directory name as default Compose project name.
+        name="$( basename "$( pwd -P )" )"
+        export COMPOSE_PROJECT_NAME="$name";
+    fi
+fi
+
+if [ ! -d "$MOODLE_DOCKER_WWWROOT" ]; then
+    echo 'Error: MOODLE_DOCKER_WWWROOT is not set or not an existing directory'
+    exit 1
+fi
+
+if [ -z "$MOODLE_DOCKER_DB" ];
+then
+    echo 'Error: MOODLE_DOCKER_DB is not set'
+    exit 1
+fi

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -7,17 +7,8 @@ set -e
 thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
 basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
 
-if [ ! -d "$MOODLE_DOCKER_WWWROOT" ];
-then
-    echo 'Error: $MOODLE_DOCKER_WWWROOT is not set or not an existing directory'
-    exit 1
-fi
-
-if [ -z "$MOODLE_DOCKER_DB" ];
-then
-    echo 'Error: $MOODLE_DOCKER_DB is not set'
-    exit 1
-fi
+# Load all environment settings.
+source "${basedir}/bin/include/env.sh"
 
 export ASSETDIR="${basedir}/assets"
 

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -1,19 +1,14 @@
 @ECHO OFF
 
-IF NOT EXIST "%MOODLE_DOCKER_WWWROOT%" (
-    ECHO Error: MOODLE_DOCKER_WWWROOT is not set or not an existing directory
-    EXIT /B 1
-)
-
-IF "%MOODLE_DOCKER_DB%"=="" (
-    ECHO Error: MOODLE_DOCKER_DB is not set
-    EXIT /B 1
-)
+setlocal
 
 PUSHD %cd%
 CD %~dp0..
 SET BASEDIR=%cd%
 POPD
+
+call %BASEDIR%\bin\include\env.cmd || EXIT /B 1
+
 SET ASSETDIR=%BASEDIR%\assets
 
 SET COMPOSE_CONVERT_WINDOWS_PATHS=true

--- a/bin/moodle-docker-wait-for-app
+++ b/bin/moodle-docker-wait-for-app
@@ -4,6 +4,9 @@ set -e
 thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
 basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
 
+# Load all environment settings.
+source "${basedir}/bin/include/env.sh"
+
 if [[ ! -z "$MOODLE_DOCKER_BROWSER" ]] && [[ "$MOODLE_DOCKER_BROWSER" == "chrome" ]] && ([[ ! -z "$MOODLE_DOCKER_APP_PATH" ]] || [[ ! -z "$MOODLE_DOCKER_APP_VERSION" ]] || [[ ! -z "$MOODLE_APP_VERSION" ]]);
 then
     until $basedir/bin/moodle-docker-compose logs moodleapp | grep -q -E 'dev server running: |Angular Live Development Server is listening|Configuration complete; ready for start up';

--- a/bin/moodle-docker-wait-for-db
+++ b/bin/moodle-docker-wait-for-db
@@ -4,11 +4,8 @@ set -e
 thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
 basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
 
-if [ -z "$MOODLE_DOCKER_DB" ];
-then
-    echo 'Error: $MOODLE_DOCKER_DB is not set'
-    exit 1
-fi
+# Load all environment settings.
+source "${basedir}/bin/include/env.sh"
 
 if [ "$MOODLE_DOCKER_DB" = "mssql" ];
 then


### PR DESCRIPTION
See the README.md for more information how to use it.

My main objectives were:

- do not require setting MOODLE_DOCKER_WWWROOT when executing compose from Moodle checkout dir
- do not require COMPOSE_PROJECT_NAME when having multiple Moodle checkouts dir
- allow the db default to be stored in some file in Moodle checkout dir


NOTE: this feature is not supported in Windows because  I do not know how to parse the env file there.