### PR TITLE
Bump to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,10 @@ jobs:
 
     steps:
       - name: Checking out moodle-docker
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checking out moodle
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: moodle/moodle
           path: moodle
@@ -118,10 +118,10 @@ jobs:
 
     steps:
       - name: Checking out moodle-docker
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checking out moodle
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: moodle/moodle
           path: moodle
@@ -172,10 +172,10 @@ jobs:
 
     steps:
       - name: Checking out moodle-docker
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Checking out moodle
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: moodle/moodle
           path: moodle


### PR DESCRIPTION
Related to this deprecation of NodeJS 12 for GHA actions:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

While it doesn't affect to this repository, let's bump to the new v3 version now so we keep it updated.