### PR TITLE
Add support for local.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+local.yml

--- a/README.md
+++ b/README.md
@@ -218,6 +218,31 @@ When you change them, use `bin/moodle-docker-compose down && bin/moodle-docker-c
 | `MOODLE_DOCKER_APP_VERSION`               | no        | a valid [app docker image version](https://docs.moodle.org/dev/Moodle_App_Docker_images) | not set       | If set will start an instance of the Moodle app if the chrome browser is selected |
 | `MOODLE_DOCKER_APP_RUNTIME`               | no        | 'ionic3' or 'ionic5'                  | not set       | Set this to indicate the runtime being used in the Moodle app. In most cases, this can be ignored because the runtime is guessed automatically (except on Windows using the `.cmd` binary). In case you need to set it manually and you're not sure which one it is, versions 3.9.5 and later should be using Ionic 5. |
 
+## Local customisations
+
+In some situations you may wish to add local customisations, such as including additional containers, or changing existing containers.
+
+This can be accomplished by specifying a `local.yml`, which will be added in and loaded with the existing yml configuration files automatically. For example:
+
+``` file="local.yml"
+version: "2"
+services:
+
+  # Add the adminer image at the latest tag on port 8080:8080
+  adminer:
+    image: adminer:latest
+    restart: always
+    ports:
+      - 8080:8080
+    depends_on:
+      - "db"
+
+  # Modify the webserver image to add another volume:
+  webserver:
+    volumes:
+      - "/opt/data:/opt/data:cached"
+```
+
 ## Using XDebug for live debugging
 
 The XDebug PHP Extension is not included in this setup and there are reasons not to include it by default.

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -201,5 +201,13 @@ if [[ "$(uname)" == "Darwin" ]]; then
     dockercompose="${dockercompose} -f ${basedir}/volumes-cached.yml"
 fi
 
+# Apply local customisations if a local.yml is found.
+# Note: This must be the final modification before the docker-compose command is called.
+localfile="${basedir}/local.yml"
+if [ -f "${localfile}" ]
+then
+  echo "Including local options from ${localfile}"
+  dockercompose="${dockercompose} -f ${localfile}"
+fi
 
 $dockercompose "$@"

--- a/bin/moodle-docker-compose.cmd
+++ b/bin/moodle-docker-compose.cmd
@@ -144,4 +144,13 @@ IF "%MOODLE_DOCKER_SELENIUM_VNC_PORT%"=="" (
     )
 )
 
+
+REM Apply local customisations if a local.yml is found.
+REM Note: This must be the final modification before the docker-compose command is called.
+SET LOCALFILE=%BASEDIR%\local.yml
+IF EXIST %LOCALFILE% (
+    ECHO Including local options from %localfile%
+    SET DOCKERCOMPOSE=%DOCKERCOMPOSE% -f "%LOCALFILE%"
+)
+
 %DOCKERCOMPOSE% %*


### PR DESCRIPTION
This change adds support for a local yml file to include any customisations that users may wish to include as standard.

This may, for example include changes to existing containers, or it may include the addition of additional containers such as database admin tooling, or proxy servers.