### PR TITLE
For sqlsrv, switch from 2017-latest to latest

### DIFF
--- a/db.mssql.yml
+++ b/db.mssql.yml
@@ -5,7 +5,7 @@ services:
       MOODLE_DOCKER_DBTYPE: sqlsrv
       MOODLE_DOCKER_DBUSER: sa
   db:
-    image: moodlehq/moodle-db-mssql:${MOODLE_DOCKER_DB_VERSION:-2017-latest}
+    image: moodlehq/moodle-db-mssql:${MOODLE_DOCKER_DB_VERSION:-latest}
     environment:
         ACCEPT_EULA: "y"
         SA_PASSWORD: "m@0dl3ing"


### PR DESCRIPTION
Note that, right now, "latest" is exactly 2017-latest, so everything will continue working exactly the same.

But once we finish with the tests @ MDLSITE-6045, we'll make 2019-latest to become "latest".