### PR TITLE
Ensure that we don't use bin logs by default

### DIFF
--- a/db.mariadb.yml
+++ b/db.mariadb.yml
@@ -11,6 +11,7 @@ services:
               --collation-server=utf8mb4_bin
               --innodb_file_per_table=On
               --wait-timeout=28800
+              --skip-log-bin
     environment:
       MYSQL_ROOT_PASSWORD: "m@0dl3ing"
       MYSQL_USER: moodle

--- a/db.mysql.yml
+++ b/db.mysql.yml
@@ -9,6 +9,7 @@ services:
     command: >
                 --character-set-server=utf8mb4
                 --collation-server=utf8mb4_bin
+                --skip-log-bin
     environment:
       MYSQL_ROOT_PASSWORD: "m@0dl3ing"
       MYSQL_USER: moodle


### PR DESCRIPTION
MySQL 8 comes with bin logs enabled, and that can end using big space on volumes for near nothing. So ensure that both MySQL and MariaDB, by default, disable them.

Note this can be changed whenever/if we want to test primary + replica configurations, but that's another story. For standalone runs better have bin logs disabled.