### PR TITLE
Add support for reading a .env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,22 @@
+# This is an example environment file for Moodle Docker.
+# This file is in the POSIX format and intended to be read by shdotenv.
+# Documentation for this file format can be found at the following location:
+# https://github.com/ko1nksm/shdotenv/blob/main/docs/specification.md
+
+# This shouold be an absolute path to your Moodle source directory.
+MOODLE_DOCKER_WWWROOT=/absolute/path/to/Moodle/on/host
+
+# The port number for web.
+MOODLE_DOCKER_WEB_PORT=1234
+
+# The database server type to use.
+# Valid options are pgsql, mysql, mariadb, oci, sqlsrv.
+MOODLE_DOCKER_DB=pgsql
+
+# The database credentials to use.
+MOODLE_DOCKER_DBNAME=moodle
+MOODLE_DOCKER_DBUSER=moodle
+MOODLE_DOCKER_DBPASS="m@0dl3ing"
+
+# The browser environment to bring up for any Behat tests
+MOODLE_DOCKER_BROWSER=firefox

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 local.yml
+.env
+shdotenv

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ bin/moodle-docker-wait-for-db
 # Shut down and destroy containers
 bin/moodle-docker-compose down
 ```
+
+## Configuration
+
+If you are running a *nix-like OS such as Linux, or MacOS, then you can provide a local `.env` file to setup your default environment. This file only provides _default_ configuration for any environment variable not already set in your environment. If you wish to override a setting from the default you can do so in the normal way using an export command.
+
+An example environment file is provided in [`.env.example`](https://github.com/moodlehq/moodle-docker/master/blob/.env.example).
+
+Environment file configuration is loaded using [shdotenv](https://github.com/ko1nksm/shdotenv) and the `.env` file should be in the [POSIX dialect](https://github.com/ko1nksm/shdotenv/blob/main/docs/specification.md).
+
+Please note that this file _should not_ be added to your git repository. It is intended to contain your _local_ default configuration.
+
 ## Run several Moodle instances
 
 By default, the script will load a single instance. If you want to run two

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -7,6 +7,19 @@ set -e
 thisfile=$( readlink "${BASH_SOURCE[0]}" ) || thisfile="${BASH_SOURCE[0]}"
 basedir="$( cd "$( dirname "$thisfile" )/../" && pwd -P )"
 
+# Check for an environent file, and import it if found.
+ENVFILE="${basedir}/.env"
+if [ -f "$ENVFILE" ]
+then
+     SHDOTENV="${basedir}/shdotenv"
+    if [ ! -f "${SHDOTENV}" ]
+    then
+        curl https://github.com/ko1nksm/shdotenv/releases/latest/download/shdotenv -L -o "${SHDOTENV}"
+        chmod +x "${SHDOTENV}"
+    fi
+    eval "$(./shdotenv || echo "exit $?")"
+fi
+
 if [ ! -d "$MOODLE_DOCKER_WWWROOT" ];
 then
     echo 'Error: $MOODLE_DOCKER_WWWROOT is not set or not an existing directory'


### PR DESCRIPTION
This commit adds support for a .env file to provide default environment configuration using the [shdotenv](https://github.com/ko1nksm/shdotenv) project with an environment file in the [POSIX format](https://github.com/ko1nksm/shdotenv/blob/main/docs/specification.md).

I have not (yet) been able to find a Window variant of shdotenv, and I'm not sure if there's already something built-in to Powershell or similar so this remains a Linux/MacOS feature for now.