### PR TITLE
Enable php81 tests for 401_STABLE and master (4.2dev)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
       matrix:
         include:
           # PostgreSQL (highest, lowest php supported)
-          #- { branch: master,            php: "8.1", database: pgsql, suite: phpunit-full } # Full run only for master.
+          - { branch: master,            php: "8.1", database: pgsql, suite: phpunit-full } # Full run only for master.
           - { branch: master,            php: "8.0", database: pgsql, suite: phpunit-full }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: pgsql, suite: phpunit } # Other branches, quicker run.
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: pgsql, suite: phpunit } # Other branches, quicker run.
           - { branch: MOODLE_401_STABLE, php: "7.4", database: pgsql, suite: phpunit }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: pgsql, suite: phpunit }
           - { branch: MOODLE_400_STABLE, php: "7.3", database: pgsql, suite: phpunit }
@@ -31,20 +31,20 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.2", database: mariadb, suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, suite: phpunit }
           # Other databases (highest php supported)
-          - { branch: master,            php: "8.0", database: mssql,  suite: phpunit }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: mssql,  suite: phpunit }
+          - { branch: master,            php: "8.1", database: mssql,  suite: phpunit }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: mssql,  suite: phpunit }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: mssql,  suite: phpunit }
           - { branch: MOODLE_311_STABLE, php: "8.0", database: mssql,  suite: phpunit }
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  suite: phpunit }
-          - { branch: master,            php: "8.0", database: mysql,  suite: phpunit }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: mysql,  suite: phpunit }
+          - { branch: master,            php: "8.1", database: mysql,  suite: phpunit }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: mysql,  suite: phpunit }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: mysql,  suite: phpunit }
           - { branch: MOODLE_311_STABLE, php: "8.0", database: mysql,  suite: phpunit }
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  suite: phpunit }
-          - { branch: master,            php: "8.0", database: oracle, suite: phpunit }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: oracle, suite: phpunit }
+          - { branch: master,            php: "8.1", database: oracle, suite: phpunit }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: oracle, suite: phpunit }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: oracle, suite: phpunit }
           - { branch: MOODLE_311_STABLE, php: "8.0", database: oracle, suite: phpunit }
           - { branch: MOODLE_310_STABLE, php: "7.4", database: oracle, suite: phpunit }
@@ -89,9 +89,9 @@ jobs:
       matrix:
         include:
           # PostgreSQL (highest, lowest php supported)
-          #- { branch: master,            php: "8.1", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: master,            php: "8.1", database: pgsql, browser: chrome,  suite: behat }
           - { branch: master,            php: "8.0", database: pgsql, browser: firefox, suite: behat }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: pgsql, browser: chrome,  suite: behat }
           - { branch: MOODLE_401_STABLE, php: "7.4", database: pgsql, browser: firefox, suite: behat }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: pgsql, browser: chrome,  suite: behat }
           - { branch: MOODLE_400_STABLE, php: "7.3", database: pgsql, browser: firefox, suite: behat }
@@ -109,20 +109,20 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.2", database: mariadb, browser: chrome,  suite: behat }
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, browser: firefox, suite: behat }
           # Other databases (highest php supported")
-          - { branch: master,            php: "8.0", database: mssql,  browser: chrome,  suite: behat }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: mssql,  browser: firefox, suite: behat }
+          - { branch: master,            php: "8.1", database: mssql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: mssql,  browser: firefox, suite: behat }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: mssql,  browser: firefox, suite: behat }
           - { branch: MOODLE_311_STABLE, php: "8.0", database: mssql,  browser: firefox, suite: behat }
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  browser: chrome,  suite: behat }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  browser: firefox, suite: behat }
-          - { branch: master,            php: "8.0", database: mysql,  browser: chrome,  suite: behat }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: mysql,  browser: firefox, suite: behat }
+          - { branch: master,            php: "8.1", database: mysql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_311_STABLE, php: "8.0", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  browser: chrome,  suite: behat }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  browser: firefox, suite: behat }
-          - { branch: master,            php: "8.0", database: oracle, browser: chrome,  suite: behat }
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: oracle, browser: firefox, suite: behat }
+          - { branch: master,            php: "8.1", database: oracle, browser: chrome,  suite: behat }
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: oracle, browser: firefox, suite: behat }
           - { branch: MOODLE_400_STABLE, php: "8.0", database: oracle, browser: firefox, suite: behat }
           - { branch: MOODLE_311_STABLE, php: "8.0", database: oracle, browser: firefox, suite: behat }
           - { branch: MOODLE_310_STABLE, php: "7.4", database: oracle, browser: chrome,  suite: behat }
@@ -173,9 +173,9 @@ jobs:
           - { branch: MOODLE_311_STABLE, php: "8.0", database: pgsql, runtime: ionic3, suite: app, app-version: "3.9.0"}
           - { branch: MOODLE_311_STABLE, php: "7.3", database: pgsql, runtime: ionic3, suite: app, app-version: "3.9.0"}
 
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: pgsql, runtime: ionic5, suite: app-development, app-version: "4.0.0"}
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: pgsql, runtime: ionic5, suite: app-development, app-version: "4.0.0"}
           - { branch: MOODLE_401_STABLE, php: "7.4", database: pgsql, runtime: ionic5, suite: app-development, app-version: "4.0.0"}
-          - { branch: MOODLE_401_STABLE, php: "8.0", database: pgsql, runtime: ionic5, suite: app, app-version: "4.0.0-dev"}
+          - { branch: MOODLE_401_STABLE, php: "8.1", database: pgsql, runtime: ionic5, suite: app, app-version: "4.0.0-dev"}
           - { branch: MOODLE_401_STABLE, php: "7.4", database: pgsql, runtime: ionic5, suite: app, app-version: "4.0.0-dev"}
           - { branch: MOODLE_400_STABLE, php: "8.0", database: pgsql, runtime: ionic5, suite: app-development, app-version: "4.0.0"}
           - { branch: MOODLE_400_STABLE, php: "7.3", database: pgsql, runtime: ionic5, suite: app-development, app-version: "4.0.0"}


### PR DESCRIPTION
This is part of the php81 epic:

https://tracker.moodle.org/browse/MDL-73016

It's near completed and passing in CIs, so let's enable the php81 tests for both MOODLE_401_STABLE and master (4.2dev).