### PR TITLE
Disable sqlsrv encryption by default

### DIFF
--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -13,6 +13,14 @@ $CFG->dbpass    = getenv('MOODLE_DOCKER_DBPASS');
 $CFG->prefix    = 'm_';
 $CFG->dboptions = ['dbcollation' => getenv('MOODLE_DOCKER_DBCOLLATION')];
 
+if (getenv('MOODLE_DOCKER_DBTYPE') === 'sqlsrv') {
+    $CFG->dboptions['extrainfo'] = [
+        // Disable Encryption for now on sqlsrv.
+        // It is on by default from msodbcsql18.
+        'Encrypt' => false,
+    ];
+}
+
 $host = 'localhost';
 if (!empty(getenv('MOODLE_DOCKER_WEB_HOST'))) {
     $host = getenv('MOODLE_DOCKER_WEB_HOST');


### PR DESCRIPTION
We don't need it, we don't want it. And, with
ODBC 18 it's enabled by default. Allowing/supporting it
in moodle-docker would require cert validations
and other stuff that we don't need for dev/test purposes.

Fixes #253