### PR TITLE
Switch to maintained multi-arch fork of mailhog/mailhog

### DIFF
--- a/service.mail.yml
+++ b/service.mail.yml
@@ -6,4 +6,4 @@ services:
     depends_on:
       - mailhog
   mailhog:
-    image: mailhog/mailhog
+    image: anatomicjc/mailhog


### PR DESCRIPTION
Note that mailhog seems to be not much supported nowadays:
- https://github.com/mailhog/MailHog/issues/307
- https://github.com/mailhog/MailHog/issues/442

And there are a bunch of alternatives, also supporting multi-arch docker images and some more stuff:
- https://github.com/maildev/maildev
- https://github.com/axllent/mailpit

Surely we should move to one of them at some point.