### PR TITLE
Replace mailhog with mailpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains Docker configuration aimed at Moodle developers and tes
 ## Features:
 * All supported database servers (PostgreSQL, MySQL, Micosoft SQL Server, Oracle XE)
 * Behat/Selenium configuration for Firefox and Chrome
-* Catch-all smtp server and web interface to messages using [MailHog](https://github.com/mailhog/MailHog/)
+* Catch-all smtp server and web interface to messages using [Mailpit](https://github.com/axllent/mailpit)
 * All PHP Extensions enabled configured for external services (e.g. solr, ldap)
 * All supported PHP versions
 * Zero-configuration approach
@@ -128,7 +128,7 @@ bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --ag
 
 Notes:
 * Moodle is configured to listen on `http://localhost:8000/`.
-* Mailhog is listening on `http://localhost:8000/_/mail` to view emails which Moodle has sent out.
+* Mailpit is listening on `http://localhost:8000/_/mail` to view emails which Moodle has sent out.
 * The admin `username` you need to use for logging in is `admin` by default. You can customize it by passing `--adminuser='myusername'`
 
 ## Use containers for running behat tests for the Moodle App

--- a/assets/web/apache2_mailpit.conf
+++ b/assets/web/apache2_mailpit.conf
@@ -12,8 +12,8 @@
 
 Redirect "/_/mail" "/_/mail/"
 
-ProxyPass "/_/mail/api/v2/websocket" "ws://mailhog:8025/api/v2/websocket"
-ProxyPassReverse "/_/mail/api/v2/websocket" "ws://mailhog:8025/api/v2/websocket"
+ProxyPass "/_/mail/api/events" "ws://mailpit:8025/api/events"
+ProxyPassReverse "/_/mail/api/events" "ws://mailpit:8025/api/events"
 
-ProxyPass "/_/mail/" "http://mailhog:8025/"
-ProxyPassReverse "/_/mail/" "http://mailhog:8025/"
+ProxyPass "/_/mail/" "http://mailpit:8025/"
+ProxyPassReverse "/_/mail/" "http://mailpit:8025/"

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -38,7 +38,7 @@ if (!empty($port)) {
 $CFG->dataroot  = '/var/www/moodledata';
 $CFG->admin     = 'admin';
 $CFG->directorypermissions = 0777;
-$CFG->smtphosts = 'mailhog:1025';
+$CFG->smtphosts = 'mailpit:1025';
 $CFG->noreplyaddress = 'noreply@example.com';
 
 // Debug options - possible to be controlled by flag in future..

--- a/service.mail.yml
+++ b/service.mail.yml
@@ -2,8 +2,8 @@ version: "2"
 services:
   webserver:
     volumes:
-      - "${ASSETDIR}/web/apache2_mailhog.conf:/etc/apache2/conf-enabled/apache2_mailhog.conf"
+      - "${ASSETDIR}/web/apache2_mailpit.conf:/etc/apache2/conf-enabled/apache2_mailpit.conf"
     depends_on:
-      - mailhog
-  mailhog:
-    image: anatomicjc/mailhog
+      - mailpit
+  mailpit:
+    image: axllent/mailpit


### PR DESCRIPTION
mailpit (https://github.com/axllent/mailpit) is a more maintained mail test client with a straightforward api.

Fixes #257