### PR TITLE
Use proper npm version to run app tests

### DIFF
--- a/tests/app-setup.sh
+++ b/tests/app-setup.sh
@@ -15,7 +15,12 @@ then
 
     if [[ $RUNTIME = ionic5 ]];
     then
-        docker run --volume $basedir/app:/app --workdir /app node:14 bash -c "npm install npm@7 -g && npm ci"
+        if [[ ! -f $basedir/app/.npmrc  || -z "$(cat $basedir/app/.npmrc | grep unsafe-perm)" ]];
+        then
+            echo -e "\nunsafe-perm=true" >> $basedir/app/.npmrc
+        fi
+
+        docker run --volume $basedir/app:/app --workdir /app node:14 bash -c "npm ci"
     else
         docker run --volume $basedir/app:/app --workdir /app node:11 npm run setup
         docker run --volume $basedir/app:/app --workdir /app node:11 npm ci


### PR DESCRIPTION
Following up from the discussion in #263, I've updated the app setup to use the proper npm version.

It seems like the errors were caused from [a known issue](https://github.com/ds300/patch-package/issues/185) in a library we're using to patch 3rd party dependencies, called [patch-package](https://www.npmjs.com/package/patch-package).

This problem could technically be happening when using `moodle-docker` locally as well, not just in the CI environment. But nobody in our team has had any problems with it so far, and given the security implications of adding the `unsafe-perm` to the app repo, I prefer to fix it just on CI.