### PR TITLE
Add some basic integration checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,36 @@ name: moodle-docker CI
 on: [push, pull_request]
 
 jobs:
+  integration:
+    name: Integration checks
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checking out moodle-docker
+        uses: actions/checkout@v3
+
+      - name: Checking out moodle
+        uses: actions/checkout@v3
+        with:
+          repository: moodle/moodle
+          path: moodle
+          ref: ${{ matrix.branch }}
+
+      - name: Prepare moodle-docker environment
+        run: |
+          cp config.docker-template.php moodle/config.php
+          tests/integration-setup.sh
+
+      - name: Run moodle-docker tests
+        run: |
+          tests/integration-test.sh
+
+      - name: Stop moodle-docker
+        run: |
+          tests/integration-teardown.sh
+
   PHPUnit:
+    needs: integration
     runs-on: ubuntu-22.04
 
     strategy:
@@ -94,6 +123,7 @@ jobs:
           tests/phpunit-teardown.sh
 
   Behat:
+    needs: integration
     runs-on: ubuntu-22.04
 
     strategy:
@@ -185,6 +215,7 @@ jobs:
           tests/behat-teardown.sh
 
   App:
+    needs: integration
     runs-on: ubuntu-22.04
 
     strategy:

--- a/tests/integration-setup.sh
+++ b/tests/integration-setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_DB=pgsql
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+
+echo "Pulling docker images"
+$basedir/bin/moodle-docker-compose pull
+echo "Starting up container"
+$basedir/bin/moodle-docker-compose up -d
+echo "Waiting for DB to come up"
+$basedir/bin/moodle-docker-wait-for-db

--- a/tests/integration-teardown.sh
+++ b/tests/integration-teardown.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+export MOODLE_DOCKER_DB=pgsql
+
+echo "Stopping down container"
+$basedir/bin/moodle-docker-compose down

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -e
+
+basedir="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+export MOODLE_DOCKER_WWWROOT="${basedir}/moodle"
+export MOODLE_DOCKER_DB=pgsql
+
+echo "Checking that PHP CLI is available"
+
+out=$("${basedir}/bin/moodle-docker-compose" exec -T webserver php -r 'echo "Up!";')
+if [[ ! "$out" =~ 'Up!' ]]; then
+    echo "Error: PHP CLI isn't available"
+    exit 1
+fi
+
+echo "Checking that the web server is up"
+
+if ! curl -s -f 'http://localhost:8000' > /dev/null; then
+    echo "Error: Webserver not available in port 8000"
+    exit 1
+fi
+
+echo "Checking that the Moodle site is ready to install"
+
+out=$(curl -s -L 'http://localhost:8000')
+if ! grep -qz 'Installation | Moodle ' <<< "$out"; then
+    echo "Error: Moodle site not ready to install"
+    exit 1
+fi
+
+echo "Checking that mailpit is up"
+
+if ! curl -s -f -L 'http://localhost:8000/_/mail' > /dev/null; then
+    echo "Error: Mailpit not available @ http://localhost:8000/_/mail"
+    exit 1
+fi
+
+echo "Checking that mailpit is using existing JS and CSS files"
+
+out=$(curl -s -L 'http://localhost:8000/_/mail')
+js=$(grep -oP '(?<=<script src=")[^"\?]+' <<< "$out")
+if ! curl -s -f "http://localhost:8000$js" > /dev/null; then
+    echo "Error: Mailpit JS not available @ http://localhost:8000$js"
+    exit 1
+fi
+css=$(grep -oP '(?<=<link rel=stylesheet href=")[^"\?]+' <<< "$out")
+if ! curl -s -f "http://localhost:8000$css" > /dev/null; then
+    echo "Error: Mailpit CSS not available @ http://localhost:8000$css"
+    exit 1
+fi


### PR DESCRIPTION
The idea with these checks is to verify that the basic moodle-docker composition is able to get up and running and that the various entry points (php, web server, mailpit...) are available.

This can be expanded in the future to run more checks verifying other services or expectations.

Fixes #274