### PR TITLE
Add Gitpod support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 local.yml
+/moodle/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,50 @@
+tasks:
+  - name: Moodle Docker
+
+    before: |
+      # Set up Moodle docker environment vars.
+      export COMPOSE_PROJECT_NAME=moodle-gitpod
+      export MOODLE_DOCKER_WWWROOT="$GITPOD_REPO_ROOT"/moodle
+      export MOODLE_DOCKER_DB=pgsql
+
+    init: |
+      # Set up Moodle repository.
+      .gitpod/setup-env.sh
+
+      # Ensure customized config.php for the Docker containers is in place
+      cp config.docker-template.php $MOODLE_DOCKER_WWWROOT/config.php
+
+      # Start up containers.
+      bin/moodle-docker-compose up -d
+
+      # Wait for DB to come up.
+      bin/moodle-docker-wait-for-db
+
+      # Initialize Moodle database for manual testing.
+      bin/moodle-docker-compose exec webserver php admin/cli/install_database.php --agree-license --fullname="Docker moodle" --shortname="docker_moodle" --summary="Docker moodle site" --adminpass="test" --adminemail="admin@example.com"
+
+      # Hack to avoid when the workspace is restarted.
+      # It can be removed when https://github.com/gitpod-io/gitpod/issues/17551 is fixed.
+      bin/moodle-docker-compose exec webserver bash -c 'rm -rf /var/log/apache2/*'
+
+      # Open Moodle site in browser.
+      gp ports await 8000 && gp preview $(gp url 8000)
+
+    command: |
+      # Update the patch to the latest version.
+      cd moodle
+      git fetch
+      git reset --hard
+      cd ..
+
+      # Start up containers.
+      bin/moodle-docker-compose up -d
+
+      # Wait for DB to come up.
+      bin/moodle-docker-wait-for-db
+
+ports:
+  - port: 8000
+    name: Moodle server
+    visibility: public
+    onOpen: ignore

--- a/.gitpod/setup-env.sh
+++ b/.gitpod/setup-env.sh
@@ -1,0 +1,12 @@
+# Initialize variables to get Moodle code.
+if [ -z "$MOODLE_REPOSITORY" ];
+then
+    export MOODLE_REPOSITORY=https://github.com/moodle/moodle.git
+fi
+if [ -z "$MOODLE_BRANCH" ];
+then
+    export MOODLE_BRANCH=main
+fi
+
+# Clone Moodle repository.
+cd "${GITPOD_REPO_ROOT}" && git clone --branch "${MOODLE_BRANCH}" --single-branch "${MOODLE_REPOSITORY}" moodle

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Notes:
 * The admin `username` you need to use for logging in is `admin` by default. You can customize it by passing `--adminuser='myusername'`
 * During manual testing, if you are facing that your Moodle site is logging
  you off continuously, putting the correct credentials, clean all cookies
- for your Moodle site URL (usually `localhost`) from your browser. 
+ for your Moodle site URL (usually `localhost`) from your browser.
  [More info](https://github.com/moodlehq/moodle-docker/issues/256).
 
 ## Use containers for running behat tests for the Moodle App
@@ -302,6 +302,37 @@ moodle-docker-compose restart webserver
 As can be seen in [bin/moodle-docker-compose](https://github.com/moodlehq/moodle-docker/blob/master/bin/moodle-docker-compose),
 this repo is just a series of Docker Compose configurations and light wrapper which make use of companion docker images. Each part
 is designed to be reusable and you are encouraged to use the docker [compose] commands as needed.
+
+## Quick start with Gitpod
+
+Gitpod is a free, cloud-based, development environment providing VS Code and a suitable development environment right in your browser.
+
+When launching a workspace in Gitpod, it will automatically:
+
+* Clone the Moodle repo into the `<workspace>/moodle` folder.
+* Initialise the Moodle database.
+* Start the Moodle webserver.
+
+<p>
+    <a href="https://gitpod.io/#https://github.com/moodlehq/moodle-docker" target="_blank" rel="noopener noreferrer">
+        <img loading="lazy" src="https://gitpod.io/button/open-in-gitpod.svg" alt="Open in Gitpod" class="img_ev3q">
+    </a>
+</p>
+
+> **IMPORTANT**: Gitpod is an alternative to local development and completely optional. We recommend setting up a local development environment if you plan to contribute regularly.
+
+The Moodle Gitpod template supports the following environment variables:
+
+* `MOODLE_REPOSITORY`. The Moodle repository to be cloned. The value should be URL encoded. If left undefined, the default repository `https://github.com/moodle/moodle.git` is used.
+* `MOODLE_BRANCH`. The Moodle branch to be cloned. If left undefined, the default branch `main` is employed.
+
+For a practical demonstration, launch a Gitpod workspace with the 'main' branch patch for [MDL-79912](https://tracker.moodle.org/browse/MDL-79912). Simply open the following URL in your web browser (note that MOODLE_REPOSITORY should be URL encoded). The password for the admin user is **test**:
+
+```
+https://gitpod.io/#MOODLE_REPOSITORY=https%3A%2F%2Fgithub.com%2Fsarjona%2Fmoodle.git,MOODLE_BRANCH=MDL-79912-main/https://github.com/moodlehq/moodle-docker
+```
+
+To optimize your browsing experience, consider integrating the [Tampermonkey extension](https://www.tampermonkey.net/) into your preferred web browser for added benefits. Afterward, install the Gitpod script, which can be accessed via the following URL: [Gitpod script](https://gist.githubusercontent.com/sarjona/9fc728eb2d2b41a783ea03afd6a6161e/raw/gitpod.js). This script efficiently incorporates a button adjacent to each branch within the Moodle tracker, facilitating the effortless initiation of a Gitpod workspace tailored to the corresponding patch for the issue you're currently viewing.
 
 ## Companion docker images
 

--- a/config.docker-template.php
+++ b/config.docker-template.php
@@ -21,20 +21,33 @@ if (getenv('MOODLE_DOCKER_DBTYPE') === 'sqlsrv') {
     ];
 }
 
-$host = 'localhost';
-if (!empty(getenv('MOODLE_DOCKER_WEB_HOST'))) {
-    $host = getenv('MOODLE_DOCKER_WEB_HOST');
+if (empty($_SERVER['HTTP_HOST'])) {
+    $_SERVER['HTTP_HOST'] = 'localhost';
 }
-$CFG->wwwroot   = "http://{$host}";
-$port = getenv('MOODLE_DOCKER_WEB_PORT');
-if (!empty($port)) {
-    // Extract port in case the format is bind_ip:port.
-    $parts = explode(':', $port);
-    $port = end($parts);
-    if ((string)(int)$port === (string)$port) { // Only if it's int value.
-        $CFG->wwwroot .= ":{$port}";
+if (strpos($_SERVER['HTTP_HOST'], '.gitpod.io') !== false) {
+    // Gitpod.io deployment.
+    $CFG->wwwroot   = 'https://' . $_SERVER['HTTP_HOST'];
+    $CFG->sslproxy = true;
+    // To avoid registration form.
+    $CFG->site_is_public = false;
+} else {
+    // Docker deployment.
+    $host = 'localhost';
+    if (!empty(getenv('MOODLE_DOCKER_WEB_HOST'))) {
+        $host = getenv('MOODLE_DOCKER_WEB_HOST');
+    }
+    $CFG->wwwroot   = "http://{$host}";
+    $port = getenv('MOODLE_DOCKER_WEB_PORT');
+    if (!empty($port)) {
+        // Extract port in case the format is bind_ip:port.
+        $parts = explode(':', $port);
+        $port = end($parts);
+        if ((string)(int)$port === (string)$port) { // Only if it's int value.
+            $CFG->wwwroot .= ":{$port}";
+        }
     }
 }
+
 $CFG->dataroot  = '/var/www/moodledata';
 $CFG->admin     = 'admin';
 $CFG->directorypermissions = 0777;


### PR DESCRIPTION
During my project week, I've been working on this feature to implement a mechanism for easily deploying and testing Moodle tracker issues.
Gitpod is a free, cloud-based, development environment providing a suitable development environment right in your browser.

The Moodle Gitpod template supports the following environment variables:

* `MOODLE_REPOSITORY`. The Moodle repository to be cloned. The value should be URL encoded. If left undefined, the default repository `https://github.com/moodle/moodle.git` is used.
* `MOODLE_BRANCH`. The Moodle branch to be cloned. If left undefined, the default branch `main` is employed.

In case it helps, for adding the gitpod.yml I followed the official documentation: https://www.gitpod.io/docs/references/gitpod-yml