### PR TITLE
Increase default PHP version to 8.1 for behat GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         include:
           # PostgreSQL (highest, lowest php supported)
           - { branch: master,            php: "8.2", database: pgsql, browser: chrome,  suite: behat }
-          - { branch: master,            php: "8.0", database: pgsql, browser: firefox, suite: behat }
+          - { branch: master,            php: "8.1", database: pgsql, browser: firefox, suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: pgsql, browser: chrome,  suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: pgsql, browser: firefox, suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: pgsql, browser: chrome,  suite: behat }
@@ -148,7 +148,7 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: pgsql, browser: chrome,  suite: behat }
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: pgsql, browser: firefox, suite: behat }
           # MariaDB (lowest php supported)
-          - { branch: master,            php: "8.0", database: mariadb, browser: chrome,  suite: behat }
+          - { branch: master,            php: "8.1", database: mariadb, browser: chrome,  suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: mariadb, browser: firefox, suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.0", database: mariadb, browser: firefox, suite: behat }
           - { branch: MOODLE_401_STABLE, php: "7.4", database: mariadb, browser: chrome,  suite: behat }


### PR DESCRIPTION
In https://github.com/moodlehq/moodle-docker/pull/277 I'm getting some failures with a couple of behat failures jobs and looking at them I think last week, when https://github.com/moodlehq/moodle-docker/pull/276 was integrated, there were a couple of missing places where the PHP version needed to be updated to.