### PR TITLE
Add MOODLE_DOCKER_RUNNING env variable to flag moodle-docker container run

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,19 @@ When you change them, use `bin/moodle-docker-compose down && bin/moodle-docker-c
 | `MOODLE_DOCKER_APP_PATH`                  | no        | path on your file system              | not set       | If set and the chrome browser is selected, it will start an instance of the Moodle app from your local codebase |
 | `MOODLE_DOCKER_APP_VERSION`               | no        | a valid [app docker image version](https://docs.moodle.org/dev/Moodle_App_Docker_images) | not set       | If set will start an instance of the Moodle app if the chrome browser is selected |
 
+In addition to that, `MOODLE_DOCKER_RUNNING=1` env variable is defined and available
+in the webserver container to flag being run by `moodle-docker`. Developer
+can use this to conditionally make changes in `config.php`. The common case is
+to load test-specific configuration:
+```
+// Load moodle-docker config file if we are in moodle-docker environment
+if (getenv('MOODLE_DOCKER_RUNNING')) {
+    require_once($CFG->dirroot . '/config.docker-template.php');
+}
+
+require_once($CFG->dirroot . '/lib/setup.php'); // Do not edit.
+```
+
 ## Local customisations
 
 In some situations you may wish to add local customisations, such as including additional containers, or changing existing containers.

--- a/base.yml
+++ b/base.yml
@@ -7,6 +7,7 @@ services:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html"
       - "${ASSETDIR}/web/apache2_faildumps.conf:/etc/apache2/conf-enabled/apache2_faildumps.conf"
     environment:
+      MOODLE_DOCKER_RUNNING: 1
       MOODLE_DOCKER_DBNAME: moodle
       MOODLE_DOCKER_DBUSER: moodle
       MOODLE_DOCKER_DBPASS: "m@0dl3ing"


### PR DESCRIPTION
MOODLE_DOCKER_RUNNING=1 is available inside webserver container, this can be used to conditionally load test configuration.

Closes #285