### PR TITLE
Add MOODLE_404_STABLE GHA tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,8 @@ jobs:
           # PostgreSQL (highest, lowest php supported)
           - { branch: main,              php: "8.3", database: pgsql, suite: phpunit-full } # Full run only for main.
           - { branch: main,              php: "8.1", database: pgsql, suite: phpunit-full }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: pgsql, suite: phpunit } # Other branches, quicker run.
+          - { branch: MOODLE_404_STABLE, php: "8.1", database: pgsql, suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: pgsql, suite: phpunit } # Other branches, quicker run.
           - { branch: MOODLE_403_STABLE, php: "8.0", database: pgsql, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: pgsql, suite: phpunit }
@@ -58,6 +60,7 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: pgsql, suite: phpunit }
           # MariaDB (lowest php supported)
           - { branch: main,              php: "8.1", database: mariadb, suite: phpunit }
+          - { branch: MOODLE_404_STABLE, php: "8.1", database: mariadb, suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: mariadb, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.0", database: mariadb, suite: phpunit }
           - { branch: MOODLE_401_STABLE, php: "7.4", database: mariadb, suite: phpunit }
@@ -67,6 +70,7 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, suite: phpunit }
           # Other databases (highest php supported)
           - { branch: main,              php: "8.3", database: mssql,  suite: phpunit }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: mssql,  suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: mssql,  suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: mssql,  suite: phpunit }
           - { branch: MOODLE_401_STABLE, php: "8.1", database: mssql,  suite: phpunit }
@@ -75,6 +79,7 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  suite: phpunit }
           - { branch: main,              php: "8.3", database: mysql,  suite: phpunit }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: mysql,  suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: mysql,  suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: mysql,  suite: phpunit }
           - { branch: MOODLE_401_STABLE, php: "8.1", database: mysql,  suite: phpunit }
@@ -83,6 +88,7 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  suite: phpunit }
           - { branch: main,              php: "8.3", database: oracle, suite: phpunit }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: oracle, suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: oracle, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: oracle, suite: phpunit }
           - { branch: MOODLE_401_STABLE, php: "8.1", database: oracle, suite: phpunit }
@@ -133,6 +139,8 @@ jobs:
           # PostgreSQL (highest, lowest php supported)
           - { branch: main,              php: "8.3", database: pgsql, browser: chrome,  suite: behat }
           - { branch: main,              php: "8.1", database: pgsql, browser: firefox, suite: behat }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: pgsql, browser: chrome,  suite: behat }
+          - { branch: MOODLE_404_STABLE, php: "8.1", database: pgsql, browser: firefox, suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: pgsql, browser: chrome,  suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: pgsql, browser: firefox, suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: pgsql, browser: chrome,  suite: behat }
@@ -149,6 +157,7 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: pgsql, browser: firefox, suite: behat }
           # MariaDB (lowest php supported)
           - { branch: main,              php: "8.1", database: mariadb, browser: chrome,  suite: behat }
+          - { branch: MOODLE_404_STABLE, php: "8.1", database: mariadb, browser: firefox, suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: mariadb, browser: firefox, suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.0", database: mariadb, browser: firefox, suite: behat }
           - { branch: MOODLE_401_STABLE, php: "7.4", database: mariadb, browser: chrome,  suite: behat }
@@ -158,6 +167,7 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, browser: chrome,  suite: behat }
           # Other databases (highest php supported")
           - { branch: main,              php: "8.3", database: mssql,  browser: firefox, suite: behat }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: mssql,  browser: chrome,  suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: mssql,  browser: chrome,  suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: mssql,  browser: chrome,  suite: behat }
           - { branch: MOODLE_401_STABLE, php: "8.1", database: mssql,  browser: firefox, suite: behat }
@@ -166,6 +176,7 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  browser: chrome,  suite: behat }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  browser: firefox, suite: behat }
           - { branch: main,              php: "8.3", database: mysql,  browser: chrome,  suite: behat }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_401_STABLE, php: "8.1", database: mysql,  browser: chrome,  suite: behat }
@@ -174,6 +185,7 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  browser: firefox, suite: behat }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  browser: chrome,  suite: behat }
           - { branch: main,              php: "8.3", database: oracle, browser: firefox, suite: behat }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: oracle, browser: chrome,  suite: behat }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: oracle, browser: chrome,  suite: behat }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: oracle, browser: chrome,  suite: behat }
           - { branch: MOODLE_401_STABLE, php: "8.1", database: oracle, browser: firefox, suite: behat }
@@ -224,14 +236,16 @@ jobs:
         include:
           # PostgreSQL (highest, lowest php supported)
           # First tests are for app developers.
-          - { branch: MOODLE_403_STABLE, php: "8.2", suite: app-development, app-version: "latest" }
-          - { branch: MOODLE_403_STABLE, php: "8.0", suite: app-development, app-version: "latest" }
-          - { branch: MOODLE_403_STABLE, php: "8.2", suite: app-development, app-version: "main" }
-          - { branch: MOODLE_403_STABLE, php: "8.0", suite: app-development, app-version: "main" }
+          - { branch: MOODLE_404_STABLE, php: "8.3", suite: app-development, app-version: "latest" }
+          - { branch: MOODLE_404_STABLE, php: "8.1", suite: app-development, app-version: "latest" }
+          - { branch: MOODLE_404_STABLE, php: "8.3", suite: app-development, app-version: "main" }
+          - { branch: MOODLE_404_STABLE, php: "8.1", suite: app-development, app-version: "main" }
           # Tests for Moodle plugin developers who want to test against the next version of the app.
-          - { branch: MOODLE_403_STABLE, php: "8.2", suite: app, app-version: "next-test" }
-          - { branch: MOODLE_403_STABLE, php: "8.0", suite: app, app-version: "next-test" }
+          - { branch: MOODLE_404_STABLE, php: "8.3", suite: app, app-version: "next-test" }
+          - { branch: MOODLE_404_STABLE, php: "8.1", suite: app, app-version: "next-test" }
           # Tests for Moodle plugin developers testing against all supported versions of Moodle.
+          - { branch: MOODLE_404_STABLE, php: "8.3", suite: app, app-version: "latest-test" }
+          - { branch: MOODLE_404_STABLE, php: "8.1", suite: app, app-version: "latest-test" }
           - { branch: MOODLE_403_STABLE, php: "8.2", suite: app, app-version: "latest-test" }
           - { branch: MOODLE_403_STABLE, php: "8.0", suite: app, app-version: "latest-test" }
           - { branch: MOODLE_402_STABLE, php: "8.2", suite: app, app-version: "latest-test" }


### PR DESCRIPTION
Basically, duplicate all 403 entries to 404 and amend highest/lowest PHP versions for all the new ones.

But for the app tests, where we (agreed with the apps team)
just replace the previous (403) with 404 in the first 2
groups of tests, and add in the 3rd group.