### PR TITLE
Gitpoddata

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -30,6 +30,9 @@ tasks:
       # Open Moodle site in browser.
       gp ports await 8000 && gp preview $(gp url 8000)
 
+      # Change permissions to allow installation of plugins.
+      bin/moodle-docker-compose exec webserver bash -c 'chmod -R 777 .'
+
     command: |
       # Update the patch to the latest version.
       cd moodle

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -33,6 +33,12 @@ tasks:
       # Change permissions to allow installation of plugins.
       bin/moodle-docker-compose exec webserver bash -c 'chmod -R 777 .'
 
+      # Add some data if the file exists.
+      if [ -r "moodle/admin/tool/generator/tests/fixtures/gitpod-basic-scenario.feature" ];
+      then
+        bin/moodle-docker-compose exec webserver php admin/tool/generator/cli/runtestscenario.php --feature=./../tests/fixtures/gitpod-basic-scenario.feature
+      fi
+
     command: |
       # Update the patch to the latest version.
       cd moodle

--- a/.gitpod/setup-env.sh
+++ b/.gitpod/setup-env.sh
@@ -8,8 +8,15 @@ then
     export MOODLE_BRANCH=main
 fi
 
+if [ -z "$CLONEALL" ];
+then
+    FASTCLONE='--depth 1'
+else
+    FASTCLONE=""
+fi
+
 # Clone Moodle repository.
-cd "${GITPOD_REPO_ROOT}" && git clone --branch "${MOODLE_BRANCH}" --single-branch "${MOODLE_REPOSITORY}" moodle
+cd "${GITPOD_REPO_ROOT}" && git clone ${FASTCLONE} --branch "${MOODLE_BRANCH}" --single-branch "${MOODLE_REPOSITORY}" moodle
 
 # Download the data file (if given). It will be used to generate some data.
 if [ -n "$DATAFILE" ];

--- a/.gitpod/setup-env.sh
+++ b/.gitpod/setup-env.sh
@@ -10,3 +10,9 @@ fi
 
 # Clone Moodle repository.
 cd "${GITPOD_REPO_ROOT}" && git clone --branch "${MOODLE_BRANCH}" --single-branch "${MOODLE_REPOSITORY}" moodle
+
+# Download the data file (if given). It will be used to generate some data.
+if [ -n "$DATAFILE" ];
+then
+    wget -O moodle/admin/tool/generator/tests/fixtures/gitpod-basic-scenario.feature "${DATAFILE}"
+fi

--- a/.gitpod/setup-env.sh
+++ b/.gitpod/setup-env.sh
@@ -16,3 +16,19 @@ if [ -n "$DATAFILE" ];
 then
     wget -O moodle/admin/tool/generator/tests/fixtures/gitpod-basic-scenario.feature "${DATAFILE}"
 fi
+
+# Install adminer.
+if [ -n "$INSTALLADMINER" ];
+then
+cat << EOF > local.yml
+services:
+
+  adminer:
+    image: adminer:latest
+    restart: always
+    ports:
+      - 8080:8080
+    depends_on:
+      - "db"
+EOF
+fi

--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ The Moodle Gitpod template supports the following environment variables:
 * `MOODLE_REPOSITORY`. The Moodle repository to be cloned. The value should be URL encoded. If left undefined, the default repository `https://github.com/moodle/moodle.git` is used.
 * `MOODLE_BRANCH`. The Moodle branch to be cloned. If left undefined, the default branch `main` is employed.
 * `DATAFILE`. When specified, this feature URL initializes the Moodle site with essential data. The value should be URL encoded. The content of this file adheres to the [Behat generators format](https://moodledev.io/general/development/tools/generator#create-a-testing-scenario-using-behat-generators) for creating testing scenarios.
+* `INSTALLADMINER`. Add this variable, set to any value, to install [adminer](https://www.adminer.org/).
 
 For a practical demonstration, launch a Gitpod workspace with the 'main' branch patch for [MDL-79912](https://tracker.moodle.org/browse/MDL-79912). Simply open the following URL in your web browser (note that MOODLE_REPOSITORY should be URL encoded). The password for the **admin** user is **test**:
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ The Moodle Gitpod template supports the following environment variables:
 * `MOODLE_BRANCH`. The Moodle branch to be cloned. If left undefined, the default branch `main` is employed.
 * `DATAFILE`. When specified, this feature URL initializes the Moodle site with essential data. The value should be URL encoded. The content of this file adheres to the [Behat generators format](https://moodledev.io/general/development/tools/generator#create-a-testing-scenario-using-behat-generators) for creating testing scenarios.
 * `INSTALLADMINER`. Add this variable, set to any value, to install [adminer](https://www.adminer.org/).
+* `CLONEALL`. If not set, a shallow clone is created, truncating the history to reduce the clone size. Set to `1` for a full clone.
 
 For a practical demonstration, launch a Gitpod workspace with the 'main' branch patch for [MDL-79912](https://tracker.moodle.org/browse/MDL-79912). Simply open the following URL in your web browser (note that MOODLE_REPOSITORY should be URL encoded). The password for the **admin** user is **test**:
 

--- a/README.md
+++ b/README.md
@@ -341,8 +341,9 @@ The Moodle Gitpod template supports the following environment variables:
 
 * `MOODLE_REPOSITORY`. The Moodle repository to be cloned. The value should be URL encoded. If left undefined, the default repository `https://github.com/moodle/moodle.git` is used.
 * `MOODLE_BRANCH`. The Moodle branch to be cloned. If left undefined, the default branch `main` is employed.
+* `DATAFILE`. When specified, this feature URL initializes the Moodle site with essential data. The value should be URL encoded. The content of this file adheres to the [Behat generators format](https://moodledev.io/general/development/tools/generator#create-a-testing-scenario-using-behat-generators) for creating testing scenarios.
 
-For a practical demonstration, launch a Gitpod workspace with the 'main' branch patch for [MDL-79912](https://tracker.moodle.org/browse/MDL-79912). Simply open the following URL in your web browser (note that MOODLE_REPOSITORY should be URL encoded). The password for the admin user is **test**:
+For a practical demonstration, launch a Gitpod workspace with the 'main' branch patch for [MDL-79912](https://tracker.moodle.org/browse/MDL-79912). Simply open the following URL in your web browser (note that MOODLE_REPOSITORY should be URL encoded). The password for the **admin** user is **test**:
 
 ```
 https://gitpod.io/#MOODLE_REPOSITORY=https%3A%2F%2Fgithub.com%2Fsarjona%2Fmoodle.git,MOODLE_BRANCH=MDL-79912-main/https://github.com/moodlehq/moodle-docker


### PR DESCRIPTION
Added a few improvements to the Gitpod integration:

- Set gitpod folder permission to install plugins
- Initialise gitpod with data when DATAFILE variable is given
- Add adminer to gitpod (only when INSTALLADMINER variable is given)
- Add parameter to speed gitpod clone. By default, a shallow clone is used when downloading the moodle.git repository. For a full clone, the parameter CLONEALL can be used.
