### PR TITLE
Fall back to ionic7 app runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,10 +252,10 @@ jobs:
           - { branch: MOODLE_402_STABLE, php: "8.0", suite: app, app-version: "latest-test" }
           - { branch: MOODLE_401_STABLE, php: "8.1", suite: app, app-version: "latest-test" }
           - { branch: MOODLE_401_STABLE, php: "7.4", suite: app, app-version: "latest-test" }
-          - { branch: MOODLE_400_STABLE, php: "8.0", suite: app, app-version: "latest-test" }
-          - { branch: MOODLE_400_STABLE, php: "7.3", suite: app, app-version: "latest-test" }
-          - { branch: MOODLE_311_STABLE, php: "8.0", suite: app, app-version: "latest-test" }
-          - { branch: MOODLE_311_STABLE, php: "7.3", suite: app, app-version: "latest-test" }
+          - { branch: MOODLE_400_STABLE, php: "8.0", suite: app, app-version: "4.3.0-test" }
+          - { branch: MOODLE_400_STABLE, php: "7.3", suite: app, app-version: "4.3.0-test" }
+          - { branch: MOODLE_311_STABLE, php: "8.0", suite: app, app-version: "4.3.0-test" }
+          - { branch: MOODLE_311_STABLE, php: "7.3", suite: app, app-version: "4.3.0-test" }
 
     steps:
       - name: Checking out moodle-docker

--- a/bin/moodle-docker-compose
+++ b/bin/moodle-docker-compose
@@ -89,13 +89,7 @@ then
                 export MOODLE_DOCKER_APP_RUNTIME="ionic5"
             fi
         else
-            # TODO always default to ionic7 after 4.4.0 release
-            if [[ $appversion = "latest"* ]];
-            then
-                export MOODLE_DOCKER_APP_RUNTIME="ionic5"
-            else
-                export MOODLE_DOCKER_APP_RUNTIME="ionic7"
-            fi
+            export MOODLE_DOCKER_APP_RUNTIME="ionic7"
         fi
     fi
 fi

--- a/tests/app-setup.sh
+++ b/tests/app-setup.sh
@@ -24,12 +24,14 @@ then
     docker run --volume $basedir/app:/app --workdir /app node:$nodeversion bash -c "npm ci"
 elif [ "$SUITE" = "app" ];
 then
-    isdevelop=`echo $MOODLE_DOCKER_APP_VERSION | grep -E -o "(next)|(latest)"`
+    branch=`echo $MOODLE_DOCKER_APP_VERSION | grep -P -o "next|latest|\d\.\d\.\d"`
 
-    branch="latest"
-    if [ "$isdevelop" = "next" ];
+    if [ "$branch" = "next" ];
     then
         branch="main"
+    elif [ "$branch" != "latest" ];
+    then
+        branch="v$branch"
     fi
 
     git clone --branch "$branch" --depth 1 https://github.com/moodlehq/moodle-local_moodleappbehat $basedir/moodle/local/moodleappbehat


### PR DESCRIPTION
We've released 4.4.0 version of the app, so `ionic7` can now be used as the default runtime.