### PR TITLE
Increase Moodle 5.0 requirements for PHPUnit too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,12 @@ jobs:
         include:
           # PostgreSQL (highest, lowest php supported)
           - { branch: main,              php: "8.3", database: pgsql, suite: phpunit-full } # Full run only for main.
-          - { branch: main,              php: "8.1", database: pgsql, suite: phpunit-full }
-          - { branch: MOODLE_404_STABLE, php: "8.3", database: pgsql, suite: phpunit } # Other branches, quicker run.
+          - { branch: main,              php: "8.2", database: pgsql, suite: phpunit-full }
+          - { branch: MOODLE_405_STABLE, php: "8.3", database: pgsql, suite: phpunit } # Other branches, quicker run.
+          - { branch: MOODLE_405_STABLE, php: "8.1", database: pgsql, suite: phpunit }
+          - { branch: MOODLE_404_STABLE, php: "8.3", database: pgsql, suite: phpunit }
           - { branch: MOODLE_404_STABLE, php: "8.1", database: pgsql, suite: phpunit }
-          - { branch: MOODLE_403_STABLE, php: "8.2", database: pgsql, suite: phpunit } # Other branches, quicker run.
+          - { branch: MOODLE_403_STABLE, php: "8.2", database: pgsql, suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: pgsql, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: pgsql, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.0", database: pgsql, suite: phpunit }
@@ -59,7 +61,8 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: pgsql, suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: pgsql, suite: phpunit }
           # MariaDB (lowest php supported)
-          - { branch: main,              php: "8.1", database: mariadb, suite: phpunit }
+          - { branch: main,              php: "8.2", database: mariadb, suite: phpunit }
+          - { branch: MOODLE_405_STABLE, php: "8.1", database: mariadb, suite: phpunit }
           - { branch: MOODLE_404_STABLE, php: "8.1", database: mariadb, suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.0", database: mariadb, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.0", database: mariadb, suite: phpunit }
@@ -70,6 +73,7 @@ jobs:
           - { branch: MOODLE_39_STABLE,  php: "7.2", database: mariadb, suite: phpunit }
           # Other databases (highest php supported)
           - { branch: main,              php: "8.3", database: mssql,  suite: phpunit }
+          - { branch: MOODLE_405_STABLE, php: "8.3", database: mssql,  suite: phpunit }
           - { branch: MOODLE_404_STABLE, php: "8.3", database: mssql,  suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: mssql,  suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: mssql,  suite: phpunit }
@@ -79,6 +83,7 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mssql,  suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mssql,  suite: phpunit }
           - { branch: main,              php: "8.3", database: mysql,  suite: phpunit }
+          - { branch: MOODLE_405_STABLE, php: "8.3", database: mysql,  suite: phpunit }
           - { branch: MOODLE_404_STABLE, php: "8.3", database: mysql,  suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: mysql,  suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: mysql,  suite: phpunit }
@@ -88,6 +93,7 @@ jobs:
           - { branch: MOODLE_310_STABLE, php: "7.4", database: mysql,  suite: phpunit }
           - { branch: MOODLE_39_STABLE,  php: "7.4", database: mysql,  suite: phpunit }
           - { branch: main,              php: "8.3", database: oracle, suite: phpunit }
+          - { branch: MOODLE_405_STABLE, php: "8.3", database: oracle, suite: phpunit }
           - { branch: MOODLE_404_STABLE, php: "8.3", database: oracle, suite: phpunit }
           - { branch: MOODLE_403_STABLE, php: "8.2", database: oracle, suite: phpunit }
           - { branch: MOODLE_402_STABLE, php: "8.2", database: oracle, suite: phpunit }


### PR DESCRIPTION
This commit adds missing values in the phpunit matrix (missed in the last commit and raised by the GHA).

5.0 agreed environment requirements:

    - PHP 8.2
    - PostgreSQL 14
    - MySQL 8.4
    - MariaDB 10.11.0

Apart from this, the Moodle 4.5 branch has also been added to GHA.