### PR TITLE
update db.mssql.yml

### DIFF
--- a/db.mssql.yml
+++ b/db.mssql.yml
@@ -7,4 +7,5 @@ services:
     image: moodlehq/moodle-db-mssql:${MOODLE_DOCKER_DB_VERSION:-latest}
     environment:
         ACCEPT_EULA: "y"
-        SA_PASSWORD: "m@0dl3ing"
+        MSSQL_SA_PASSWORD: "m@0dl3ing"
+        MSSQL_WAIT4READY: ${MOODLE_DOCKER_DB_WAIT4READY:-60}


### PR DESCRIPTION
In sqlserver 2022 , The SA_PASSWORD environment variable is deprecated. Use MSSQL_SA_PASSWORD instead.
[environment-variables](https://learn.microsoft.com/en-us/sql/linux/sql-server-linux-configure-environment-variables?view=sql-server-ver16#environment-variables)