### PR TITLE
Disable Apache FallbackResource for faildumps

### DIFF
--- a/assets/web/apache2_faildumps.conf
+++ b/assets/web/apache2_faildumps.conf
@@ -2,5 +2,8 @@
     Options +Indexes
 </Directory>
 
-Alias /_/faildumps /var/www/behatfaildumps
+<Location "/_/">
+    FallbackResource disabled
+</Location>
 
+Alias /_/faildumps /var/www/behatfaildumps

--- a/assets/web/apache2_faildumps.conf
+++ b/assets/web/apache2_faildumps.conf
@@ -7,3 +7,15 @@
 </Location>
 
 Alias /_/faildumps /var/www/behatfaildumps
+
+# Set the handler to use for files whose extension ends in `.php`.
+# This is a workaround for https://github.com/docker-library/php/issues/1576
+# The FallbackResource is a default Handler action which is only used if a Handler has not already been applied.
+# The docker/php image sets the handler unconditionally for any file whose name matches `.php`.
+# This configuration block unsets the default handler, and instead only applies it if the file exists.
+<FilesMatch \.php$>
+  SetHandler none
+  <If "-f %{REQUEST_FILENAME}">
+    SetHandler application/x-httpd-php
+  </If>
+</FilesMatch>

--- a/base.yml
+++ b/base.yml
@@ -5,7 +5,7 @@ services:
       - db
     volumes:
       - "${MOODLE_DOCKER_WWWROOT}:/var/www/html"
-      - "${ASSETDIR}/web/apache2_faildumps.conf:/etc/apache2/conf-enabled/apache2_faildumps.conf"
+      - "${ASSETDIR}/web/apache2_faildumps.conf:/etc/apache2/conf-enabled/moodle-faildump.conf"
     environment:
       MOODLE_DOCKER_RUNNING: 1
       MOODLE_DOCKER_DBNAME: moodle


### PR DESCRIPTION
Per docs in https://httpd.apache.org/docs/trunk/mod/mod_dir.html#fallbackresource the FallbackResource can be disabled using the {{disabled}} argument where it is set in a parent path.

Fixed #320